### PR TITLE
chore(ci): add conventional-commits and secret-scan gates

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,26 @@
+{
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "chore",
+        "docs",
+        "refactor",
+        "test",
+        "style",
+        "perf",
+        "ci",
+        "build",
+        "revert",
+        "merge"
+      ]
+    ],
+    "type-empty": [2, "never"],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 120]
+  }
+}

--- a/.github/workflows/strict-validation.yml
+++ b/.github/workflows/strict-validation.yml
@@ -100,15 +100,19 @@ jobs:
   conventional-commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Lint PR commits
-        run: npx --yes @commitlint/cli@19 --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+      - name: Lint commits
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npx --yes @commitlint/cli@19 --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+          else
+            npx --yes @commitlint/cli@19 --from "${{ github.event.before }}" --to "${{ github.event.after }}" --verbose
+          fi
 
   secret-scan:
     name: Secret Scan (gitleaks)

--- a/.github/workflows/strict-validation.yml
+++ b/.github/workflows/strict-validation.yml
@@ -96,3 +96,31 @@ jobs:
       
       - name: Check bundle size against performance-budget.json
         run: npm run check:bundle
+
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint PR commits
+        run: npx --yes @commitlint/cli@19 --from "${{ github.event.pull_request.base.sha }}" --to "${{ github.event.pull_request.head.sha }}" --verbose
+
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: 'false'


### PR DESCRIPTION
Adds two CI gates to strict-validation.yml:
- conventional-commits: enforces Conventional Commits on push AND PR (range github.event.before..after on push; base.sha..head.sha on PR).
- secret-scan: gitleaks detect on push and PR.
After merge, add both as required status checks in the main Ruleset.