### PR TITLE
fix(shared): restore GitHub/LinkedIn brand icons as inline SVGs

### DIFF
--- a/src/features/Contact/model/constants.ts
+++ b/src/features/Contact/model/constants.ts
@@ -2,7 +2,8 @@
 // Contact Feature Constants
 // ============================================
 
-import { Code2, Briefcase, Send } from 'lucide-react';
+import { Send } from 'lucide-react';
+import { GitHubIcon, LinkedInIcon } from '@/shared/ui/Icon';
 
 export const CONTACT_EMAIL = 'kostay375298918971@gmail.com';
 
@@ -10,12 +11,12 @@ export const SOCIAL_LINKS = [
   {
     name: 'GitHub',
     href: 'https://github.com/konstantin-atroshchenko',
-    icon: Code2,
+    icon: GitHubIcon,
   },
   {
     name: 'LinkedIn',
     href: 'https://linkedin.com/in/konstantin-atroshchenko',
-    icon: Briefcase,
+    icon: LinkedInIcon,
   },
   {
     name: 'Telegram',

--- a/src/shared/ui/Icon/index.ts
+++ b/src/shared/ui/Icon/index.ts
@@ -1,4 +1,5 @@
 export { getColorValue, getSizeInPixels, ICON_COLORS, ICON_SIZES } from './model/constants';
 export type { IconColor, IconProps, IconSize, IconStrokeWidth } from './model/types';
 export { Icon } from './ui/Icon';
+export { GitHubIcon, LinkedInIcon } from './ui/brandIcons';
 export { useIcon } from './lib/hooks/useIcon';

--- a/src/shared/ui/Icon/ui/brandIcons.tsx
+++ b/src/shared/ui/Icon/ui/brandIcons.tsx
@@ -1,0 +1,47 @@
+// Brand icons as inline SVGs.
+//
+// lucide-react v1 removed ALL brand icons upstream (Github, Linkedin, ...).
+// These keep the portfolio's brand fidelity without reintroducing a dependency.
+// They are cast to `LucideIcon` so they drop in wherever a lucide icon is used
+// (SOCIAL_LINKS, Link `externalIcon`, stories, tests). They accept the same
+// `size` / `className` / `style` / `aria-hidden` props a lucide icon receives.
+
+import type { LucideIcon, LucideProps } from 'lucide-react';
+
+const sharedSvgProps = {
+  viewBox: '0 0 24 24',
+  fill: 'currentColor',
+  xmlns: 'http://www.w3.org/2000/svg',
+  'aria-hidden': true,
+} as const;
+
+function GitHubIconBase({ size = 24, className, ...rest }: LucideProps) {
+  return (
+    <svg
+      {...sharedSvgProps}
+      width={size}
+      height={size}
+      className={`brand-github ${className ?? ''}`}
+      {...rest}
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.218.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+function LinkedInGlyph({ size = 24, className, ...rest }: LucideProps) {
+  return (
+    <svg
+      {...sharedSvgProps}
+      width={size}
+      height={size}
+      className={`brand-linkedin ${className ?? ''}`}
+      {...rest}
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z" />
+    </svg>
+  );
+}
+
+export const GitHubIcon = GitHubIconBase as unknown as LucideIcon;
+export const LinkedInIcon = LinkedInGlyph as unknown as LucideIcon;

--- a/src/shared/ui/Link/ui/Link.stories.tsx
+++ b/src/shared/ui/Link/ui/Link.stories.tsx
@@ -2,7 +2,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, screen, userEvent, within } from 'storybook/test';
 import type { MouseEvent, ReactNode } from 'react';
-import { ArrowRight, Code2, Briefcase, Mail } from 'lucide-react';
+import { ArrowRight, Mail } from 'lucide-react';
+import { GitHubIcon, LinkedInIcon } from '@/shared/ui/Icon';
 import { Container } from '@/shared/ui/Container';
 import { Section } from '@/shared/ui/Section';
 import { Popover } from '@/shared/ui/Popover';
@@ -214,7 +215,7 @@ export const CustomExternalIcon: Story = {
     href: 'https://github.com',
     children: 'GitHub Profile',
     external: true,
-    externalIcon: Code2,
+    externalIcon: GitHubIcon,
   },
 };
 
@@ -259,7 +260,7 @@ export const FullyFeatured: Story = {
     variant: 'primary',
     size: 'lg',
     external: true,
-    icon: <Code2 size={16} />,
+    icon: <GitHubIcon size={16} />,
     withLift: true,
     underline: 'hover',
   },
@@ -641,10 +642,10 @@ export const FooterLinkGroup: Story = {
   args: { href: '#' },
   render: () => (
     <footer data-testid="footer-group" style={{ display: 'flex', gap: '24px' }}>
-      <Link href="https://github.com" external size="sm" icon={<Code2 size={14} />}>
+      <Link href="https://github.com" external size="sm" icon={<GitHubIcon size={14} />}>
         GitHub
       </Link>
-      <Link href="https://www.linkedin.com" external size="sm" icon={<Briefcase size={14} />}>
+      <Link href="https://www.linkedin.com" external size="sm" icon={<LinkedInIcon size={14} />}>
         LinkedIn
       </Link>
       <Link href="mailto:hello@example.com" external size="sm" icon={<Mail size={14} />}>

--- a/src/shared/ui/Link/ui/Link.test.tsx
+++ b/src/shared/ui/Link/ui/Link.test.tsx
@@ -2,7 +2,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { Mail, ArrowRight, Code2 } from 'lucide-react';
+import { Mail, ArrowRight } from 'lucide-react';
+import { GitHubIcon } from '@/shared/ui/Icon';
 import { Link } from './Link';
 import linkStyles from './Link.module.scss';
 
@@ -153,16 +154,16 @@ describe('Link', () => {
 
     it('должен использовать кастомную externalIcon', () => {
       render(
-        <Link href="https://github.com" externalIcon={Code2}>
+        <Link href="https://github.com" externalIcon={GitHubIcon}>
           GitHub
         </Link>
       );
 
-      // Code2 (alias of CodeXml in lucide v1) должен рендериться (класс lucide-code-xml)
+      // GitHubIcon (inline SVG) должен рендериться (класс brand-github)
       const link = screen.getByRole('link');
       const externalIconContainer = link.querySelector(`.${linkStyles.externalIcon ?? ''}`);
       expect(externalIconContainer).toBeInTheDocument();
-      expect(externalIconContainer?.querySelector('.lucide-code-xml')).toBeInTheDocument();
+      expect(externalIconContainer?.querySelector('.brand-github')).toBeInTheDocument();
     });
 
     it('должен определять https:// как внешнюю ссылку', () => {
@@ -559,7 +560,7 @@ describe('Link', () => {
           variant="gradient"
           size="lg"
           external
-          icon={<Code2 size={20} />}
+          icon={<GitHubIcon size={20} />}
           withLift
           underline="hover"
         >


### PR DESCRIPTION
## What
lucide-react v1 removed all brand icons upstream. Restore GitHub + LinkedIn marks as inline SVG components (brandIcons.tsx), exported via the shared/ui/Icon public API.

## Why
Steps 4/6 replaced the removed Github/Linkedin icons with Code2/Briefcase placeholders; this returns real brand fidelity without a new dependency.

## How
- src/shared/ui/Icon/ui/brandIcons.tsx — GitHubIcon, LinkedInIcon (fill=currentColor, LucideIcon-compatible, className + size + style/aria-hidden passthrough)
- src/shared/ui/Icon/index.ts — re-export from public API
- src/features/Contact/model/constants.ts — SOCIAL_LINKS uses GitHubIcon/LinkedInIcon
- src/shared/ui/Link/ui/Link.stories.tsx + Link.test.tsx — updated to brand icons, test asserts .brand-github

## Validation
npm run validate: type-check + lint + lint:styles clean, 2163 tests pass, brandIcons.tsx 100% coverage.