### PR TITLE
fix(ci): inject GITHUB_TOKEN into release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
           node-version: "24"
           cache: npm
 
+      - name: Setup git for release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Фикс релиза из Ф3 (#21), который упал на пуше.

## Причина
Репозиторий имел `default_workflow_permissions=read` — GITHUB_TOKEN в workflow был read-only вне зависимости от `permissions: contents: write`. Прямой пуш semantic-release в main отклонялся: `remote rejected HEAD -> main (failure) / fatal error in commit_refs`.

## Что сделано
- Поднял `default_workflow_permissions` до `write` (gh api, владелец репо).
- `release.yml`: добавил шаг, который ставит git-user и инжектит токен в remote URL (`x-access-token:${{ secrets.GITHUB_TOKEN }}`), чтобы semantic-release аутентифицировал пуш CHANGELOG/package.json.

## После мержа
`release.yml` отработает и отсечёт **v1.0.0** + CHANGELOG.md + GitHub release по всей истории.

Closes #21