### PR TITLE
feat: add CodeQL code-security-auditor (Ф5)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,19 @@
+name: "CodeQL Config (resume)"
+
+# Сканируем только первый код приложения (src).
+paths:
+  - src
+
+# Исключаем тесты, фикстуры и артефакты сборки — они не несут
+# продакшн-уязвимостей, а только шумят в отчёте.
+paths-ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "src/tests"
+  - "src/**/__tests__"
+  - "**/node_modules"
+  - "**/dist"
+  - "**/coverage"
+  - "**/*.config.ts"
+  - "**/*.config.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+# Ф5: SAST-аудит первого кода. Дополняет npm audit (зависимости) и gitleaks (секреты).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Еженедельно в понедельник в 04:23 UTC — ловит новые паттерны между PR.
+    - cron: '23 4 * * 1'
+
+permissions:
+  # Только то, что нужно CodeQL для загрузки SARIF.
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # JS/TS анализируется по исходникам напрямую — сборка не нужна.
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"
+          upload: true


### PR DESCRIPTION
## Ф5: code-security-auditor (CodeQL)

SAST-сканер первого кода, закрывающий пробел в CI: сейчас есть только
`npm audit` (deps) и gitleaks (secrets).

### Изменения
- `.github/workflows/codeql.yml` — CodeQL на push/PR в main + weekly cron.
- `.github/codeql/codeql-config.yml` — скоп `src`, исключая тесты/фикстуры/конфиги.

### Покрывает
XSS-стоки, `dangerouslySetInnerHTML`, `eval`, слабый крипто, prototype pollution в первом коде.

### Риск
Если репо приватное без GitHub Advanced Security, job упадёт — тогда включаем AS
или переключаемся на Semgrep. Проверим по результату этого PR.

Closes #24