### PR TITLE
fix: usePopover() callable without arguments (#26)

### DIFF
--- a/src/shared/ui/Popover/lib/hooks/usePopover.test.ts
+++ b/src/shared/ui/Popover/lib/hooks/usePopover.test.ts
@@ -56,4 +56,10 @@ describe('usePopover', () => {
     act(() => result.current.close());
     expect(result.current.shouldRender).toBe(false);
   });
+
+  it('does not crash when called without options (defaults apply)', () => {
+    const { result } = renderHook(() => usePopover());
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.adjustedPosition).toBe('top');
+  });
 });

--- a/src/shared/ui/Popover/lib/hooks/usePopover.ts
+++ b/src/shared/ui/Popover/lib/hooks/usePopover.ts
@@ -66,14 +66,14 @@ interface UsePopoverOptions {
  * ```
  */
 export const usePopover = ({
-  position = POPOVER_CONSTANTS.DEFAULT_POSITION,
-  offset = POPOVER_CONSTANTS.DEFAULT_OFFSET,
+  position = POPOVER_CONSTANTS?.DEFAULT_POSITION ?? 'top',
+  offset = POPOVER_CONSTANTS?.DEFAULT_OFFSET ?? 8,
   autoAdjust = true,
   disabled = false,
   closeOnContentClick = true,
   closeOnClickOutside = true,
   closeOnEsc = true,
-}: UsePopoverOptions): UsePopoverReturn => {
+}: UsePopoverOptions = {}): UsePopoverReturn => {
   const [isVisible, setIsVisible] = useState(false);
   const [calculatedStyle, setCalculatedStyle] = useState<React.CSSProperties>({});
   const [adjustedPosition, setAdjustedPosition] = useState<PopoverPosition>(position);


### PR DESCRIPTION
## Баг
`usePopover()` без аргументов падал: параметр был обязательным (нет `= {}`),
поэтому при вызове без опций приходил `undefined` и деструктуризация
`.position` of undefined бросала ошибку.

## Фикс
- Сделать `options` опциональным: `usePopover = ({...} = {})`.
- Защитный фоллбэк: `POPOVER_CONSTANTS?.DEFAULT_POSITION ?? 'top'`.

## Проверка
- Добавлен тест: `usePopover()` без аргументов не падает, `adjustedPosition === 'top'`.
- `npm run validate` зелёный.

Closes #26