### PR TITLE
chore: ignore .opencode/profiles runtime dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .opencode/tmp/
 .opencode/cache/
 .opencode/node_modules/
+.opencode/profiles/
 
 # Log files anywhere in .opencode
 .opencode/**/*.log


### PR DESCRIPTION
## Что
Добавлена строка `.opencode/profiles/` в `.gitignore`. Это сгенерированная OpenCode директория профилей (runtime-состояние), которая не должна попадать в репо — консистентно с уже игнорируемыми `.opencode/logs/`, `context/`, `health/` и т.п.

## Почему
После синхронизации `main` с релизом 1.1.0 (`940496f`) `git status` показывал `.opencode/profiles/README.md` как untracked. Прямой пуш в `main` заблокирован Ruleset (require pull_request), поэтому правка идёт через ветку + DRAFT PR.

## Проверка
- `git status` больше не показывает `.opencode/profiles/` после игнора.
- `.gitignore` не сломан (строка добавлена в блок runtime-директорий `.opencode`).