### PR TITLE
Code: Senior+ P1 — forwardRef + slim public API (SR1-SR3)

### DIFF
--- a/src/shared/ui/Code/index.ts
+++ b/src/shared/ui/Code/index.ts
@@ -1,15 +1,6 @@
 // Main component
 export { Code } from './ui/Code';
 
-// UI components (для переиспользования)
-export { CodeInlineUi } from './ui/CodeInlineUi';
-export type { CodeInlineUiProps } from './ui/CodeInlineUi';
-export { CodeBlockUi } from './ui/CodeBlock/CodeBlock';
-export { CodeBlockHeader } from './ui/CodeBlockHeader/CodeBlockHeader';
-
-// Constants
-export { CODE_CONSTANTS, CODE_DEFAULTS, CODE_SIZES, CODE_VARIANTS } from './model/constants';
-
 // Hooks
 export { useCopyCode } from './lib/hooks/useCopyCode';
 
@@ -23,7 +14,3 @@ export type {
   CodeLanguage,
   CodeIcons,
 } from './model/types';
-
-// Utils
-export { countLines } from './lib/utils/countLines';
-export { extractTextFromNode } from './lib/utils/extractTextFromNode';

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.ts
@@ -103,5 +103,3 @@ export const useCopyCode = (
 
   return { isCopied, isError, handleCopy, reset, resetError };
 };
-
-export default useCopyCode;

--- a/src/shared/ui/Code/lib/utils/countLines.ts
+++ b/src/shared/ui/Code/lib/utils/countLines.ts
@@ -12,5 +12,3 @@ export const countLines = (node: React.ReactNode): number => {
   if (text.length === 0) return 0;
   return text.split('\n').length;
 };
-
-export default countLines;

--- a/src/shared/ui/Code/lib/utils/extractTextFromNode.ts
+++ b/src/shared/ui/Code/lib/utils/extractTextFromNode.ts
@@ -49,5 +49,3 @@ export const extractTextFromNode = (node: React.ReactNode): string => {
 
   return '';
 };
-
-export default extractTextFromNode;

--- a/src/shared/ui/Code/ui/Code.tsx
+++ b/src/shared/ui/Code/ui/Code.tsx
@@ -1,5 +1,5 @@
 import { useToast } from '@/shared/lib/contexts/ToastContext';
-import { useCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
 import type { CodeProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
 import { useCopyCode } from '../lib/hooks/useCopyCode';
@@ -12,64 +12,75 @@ import { CodeBlockUi } from './CodeBlock/CodeBlock';
  *
  * Поддерживает skeleton-режим для состояния загрузки.
  */
-export const Code: React.FC<CodeProps> = ({
-  children,
-  variant = CODE_DEFAULTS.variant,
-  onCopy,
-  skeleton = false,
-  ...props
-}) => {
-  const { addToast } = useToast();
+export const Code = forwardRef<HTMLElement, CodeProps>(
+  ({ children, variant = CODE_DEFAULTS.variant, onCopy, skeleton = false, ...props }, ref) => {
+    const { addToast } = useToast();
 
-  const { isCopied, handleCopy } = useCopyCode(children, {
-    addToast,
-    showToastOnSuccess: true,
-    showToastOnError: true,
-    onCopy,
-    enabled: !skeleton,
-  });
+    const { isCopied, handleCopy } = useCopyCode(children, {
+      addToast,
+      showToastOnSuccess: true,
+      showToastOnError: true,
+      onCopy,
+      enabled: !skeleton,
+    });
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (props.copyable && !props.disabled && (event.key === 'Enter' || event.key === ' ')) {
-        event.preventDefault();
-        handleCopy();
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent) => {
+        if (props.copyable && !props.disabled && (event.key === 'Enter' || event.key === ' ')) {
+          event.preventDefault();
+          handleCopy();
+        }
+      },
+      [props.copyable, props.disabled, handleCopy]
+    );
+
+    // Skeleton mode
+    if (skeleton) {
+      if (variant === 'block') {
+        return (
+          <CodeBlockUi
+            {...props}
+            ref={ref as React.Ref<HTMLDivElement>}
+            skeleton
+            onCopy={handleCopy}
+          >
+            {children}
+          </CodeBlockUi>
+        );
       }
-    },
-    [props.copyable, props.disabled, handleCopy]
-  );
-
-  // Skeleton mode
-  if (skeleton) {
-    if (variant === 'block') {
       return (
-        <CodeBlockUi {...props} skeleton onCopy={handleCopy}>
+        <CodeInlineUi {...props} ref={ref} skeleton onCopy={handleCopy}>
           {children}
-        </CodeBlockUi>
+        </CodeInlineUi>
       );
     }
+
+    if (variant === 'inline') {
+      return (
+        <CodeInlineUi
+          {...props}
+          ref={ref}
+          isCopied={isCopied}
+          onCopy={handleCopy}
+          onKeyDown={handleKeyDown}
+        >
+          {children}
+        </CodeInlineUi>
+      );
+    }
+
     return (
-      <CodeInlineUi {...props} skeleton onCopy={handleCopy}>
+      <CodeBlockUi
+        {...props}
+        ref={ref as React.Ref<HTMLDivElement>}
+        isCopied={isCopied}
+        onCopy={handleCopy}
+        onKeyDown={handleKeyDown}
+      >
         {children}
-      </CodeInlineUi>
+      </CodeBlockUi>
     );
   }
-
-  if (variant === 'inline') {
-    return (
-      <CodeInlineUi {...props} isCopied={isCopied} onCopy={handleCopy} onKeyDown={handleKeyDown}>
-        {children}
-      </CodeInlineUi>
-    );
-  }
-
-  return (
-    <CodeBlockUi {...props} isCopied={isCopied} onCopy={handleCopy} onKeyDown={handleKeyDown}>
-      {children}
-    </CodeBlockUi>
-  );
-};
+);
 
 Code.displayName = 'Code';
-
-export default Code;

--- a/src/shared/ui/Code/ui/CodeBlock/CodeBlock.tsx
+++ b/src/shared/ui/Code/ui/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import { classNames } from '@/shared/lib/utils/classNames';
-import { memo, useMemo } from 'react';
+import { forwardRef, memo, useMemo } from 'react';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import type { CodeBlockProps } from '../../model/types';
 import { CODE_DEFAULTS } from '../../model/constants';
@@ -21,122 +21,127 @@ export interface CodeBlockUiProps extends CodeBlockProps {
  * CodeBlock UI Component
  * Block variant для отображения кода с header и опциональной нумерацией строк
  */
-const CodeBlockUiInner: React.FC<CodeBlockUiProps> = ({
-  children,
-  language,
-  showLineNumbers = CODE_DEFAULTS.showLineNumbers,
-  copyable = CODE_DEFAULTS.copyable,
-  maxHeight,
-  title,
-  isCopied = false,
-  onCopy,
-  onKeyDown,
-  ariaLabel,
-  className,
-  disabled = CODE_DEFAULTS.disabled,
-  icons,
-  copyButtonSize = 'sm',
-  skeleton = false,
-  size = CODE_DEFAULTS.size,
-}) => {
-  const linesCount = useMemo(() => {
-    if (!showLineNumbers) return 0;
-    return countLines(children);
-  }, [children, showLineNumbers]);
+export const CodeBlockUi = memo(
+  forwardRef<HTMLDivElement, CodeBlockUiProps>(
+    (
+      {
+        children,
+        language,
+        showLineNumbers = CODE_DEFAULTS.showLineNumbers,
+        copyable = CODE_DEFAULTS.copyable,
+        maxHeight,
+        title,
+        isCopied = false,
+        onCopy,
+        onKeyDown,
+        ariaLabel,
+        className,
+        disabled = CODE_DEFAULTS.disabled,
+        icons,
+        copyButtonSize = 'sm',
+        skeleton = false,
+        size = CODE_DEFAULTS.size,
+      },
+      ref
+    ) => {
+      const linesCount = useMemo(() => {
+        if (!showLineNumbers) return 0;
+        return countLines(children);
+      }, [children, showLineNumbers]);
 
-  const hasMultipleLines = linesCount > 1;
-  const lines = useMemo(() => {
-    return Array.from({ length: linesCount }, (_, i) => i + 1);
-  }, [linesCount]);
+      const hasMultipleLines = linesCount > 1;
+      const lines = useMemo(() => {
+        return Array.from({ length: linesCount }, (_, i) => i + 1);
+      }, [linesCount]);
 
-  if (skeleton) {
-    return (
-      <div
-        className={classNames(styles.blockContainer, className)}
-        data-testid="code-block"
-        role="region"
-        aria-label={ariaLabel || (title ? `Code block: ${title}` : 'Code block')}
-        data-variant="block"
-        data-size={size}
-        data-skeleton="true"
-        aria-busy="true"
-      >
-        <CodeBlockHeader
-          language={language}
-          title={title}
-          copyable={copyable}
-          icons={icons}
-          copyButtonSize={copyButtonSize}
-          skeleton
-        />
-        <div className={styles.blockContent}>
-          <Skeleton
-            variant="rectangular"
-            width="100%"
-            height={maxHeight || '310px'}
-            aria-busy="true"
+      if (skeleton) {
+        return (
+          <div
+            ref={ref}
+            className={classNames(styles.blockContainer, className)}
+            data-testid="code-block"
+            role="region"
+            aria-label={ariaLabel || (title ? `Code block: ${title}` : 'Code block')}
+            data-variant="block"
+            data-size={size}
             data-skeleton="true"
-          />
-        </div>
-      </div>
-    );
-  }
-
-  const contentClassName = classNames(
-    styles.blockContent,
-    showLineNumbers && hasMultipleLines && styles.withLineNumbers
-  );
-
-  return (
-    <div
-      className={classNames(styles.blockContainer, className)}
-      data-testid="code-block"
-      tabIndex={0}
-      role="region"
-      aria-label={ariaLabel || (title ? `Code block: ${title}` : 'Code block')}
-      data-variant="block"
-      data-size={size}
-      data-skeleton={skeleton || undefined}
-      aria-busy={skeleton || undefined}
-    >
-      <CodeBlockHeader
-        language={language}
-        title={title}
-        copyable={copyable}
-        isCopied={isCopied}
-        onCopy={onCopy}
-        onKeyDown={onKeyDown}
-        disabled={disabled}
-        icons={icons}
-        copyButtonSize={copyButtonSize}
-      />
-
-      <div className={contentClassName} style={{ maxHeight }}>
-        {showLineNumbers && hasMultipleLines ? (
-          <>
-            <div className={styles.lineNumbers} aria-hidden="true">
-              {lines.map((lineNumber) => (
-                <div key={lineNumber} className={styles.lineNumber}>
-                  {lineNumber}
-                </div>
-              ))}
+            aria-busy="true"
+          >
+            <CodeBlockHeader
+              language={language}
+              title={title}
+              copyable={copyable}
+              icons={icons}
+              copyButtonSize={copyButtonSize}
+              skeleton
+            />
+            <div className={styles.blockContent}>
+              <Skeleton
+                variant="rectangular"
+                width="100%"
+                height={maxHeight || '310px'}
+                aria-busy="true"
+                data-skeleton="true"
+              />
             </div>
-            <pre className={styles.pre}>
-              <code>{children}</code>
-            </pre>
-          </>
-        ) : (
-          <pre className={styles.pre}>
-            <code>{children}</code>
-          </pre>
-        )}
-      </div>
-    </div>
-  );
-};
+          </div>
+        );
+      }
 
-CodeBlockUiInner.displayName = 'CodeBlockUi';
+      const contentClassName = classNames(
+        styles.blockContent,
+        showLineNumbers && hasMultipleLines && styles.withLineNumbers
+      );
 
-export const CodeBlockUi = memo(CodeBlockUiInner);
+      return (
+        <div
+          ref={ref}
+          className={classNames(styles.blockContainer, className)}
+          data-testid="code-block"
+          tabIndex={0}
+          role="region"
+          aria-label={ariaLabel || (title ? `Code block: ${title}` : 'Code block')}
+          data-variant="block"
+          data-size={size}
+          data-skeleton={skeleton || undefined}
+          aria-busy={skeleton || undefined}
+        >
+          <CodeBlockHeader
+            language={language}
+            title={title}
+            copyable={copyable}
+            isCopied={isCopied}
+            onCopy={onCopy}
+            onKeyDown={onKeyDown}
+            disabled={disabled}
+            icons={icons}
+            copyButtonSize={copyButtonSize}
+          />
 
-export default CodeBlockUi;
+          <div className={contentClassName} style={{ maxHeight }}>
+            {showLineNumbers && hasMultipleLines ? (
+              <>
+                <div className={styles.lineNumbers} aria-hidden="true">
+                  {lines.map((lineNumber) => (
+                    <div key={lineNumber} className={styles.lineNumber}>
+                      {lineNumber}
+                    </div>
+                  ))}
+                </div>
+                <pre className={styles.pre}>
+                  <code>{children}</code>
+                </pre>
+              </>
+            ) : (
+              <pre className={styles.pre}>
+                <code>{children}</code>
+              </pre>
+            )}
+          </div>
+        </div>
+      );
+    }
+  )
+);
+
+CodeBlockUi.displayName = 'CodeBlockUi';

--- a/src/shared/ui/Code/ui/CodeBlockHeader/CodeBlockHeader.tsx
+++ b/src/shared/ui/Code/ui/CodeBlockHeader/CodeBlockHeader.tsx
@@ -141,5 +141,3 @@ CodeBlockHeaderInner.displayName = 'CodeBlockHeader';
 
 /** CodeBlockHeader — обёрнут в React.memo для оптимизации ре-рендеров */
 export const CodeBlockHeader = memo(CodeBlockHeaderInner);
-
-export default CodeBlockHeader;

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -1,7 +1,7 @@
 // src/shared/ui/Code/ui/CodeInlineUi.tsx
 
 import { classNames } from '@/shared/lib/utils/classNames';
-import { memo, useCallback } from 'react';
+import { forwardRef, memo, useCallback } from 'react';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
@@ -23,66 +23,70 @@ export interface CodeInlineUiProps extends CodeInlineProps {
  * Поддерживает размеры sm/md/lg, copyable-режим с визуальным индикатором,
  * skeleton-режим для состояния загрузки и доступностью (tabIndex, role, aria-label, Enter/Space).
  */
-const CodeInlineUiInner: React.FC<CodeInlineUiProps> = ({
-  children,
-  size = CODE_DEFAULTS.size,
-  copyable = CODE_DEFAULTS.copyable,
-  isCopied = false,
-  onCopy,
-  onKeyDown,
-  ariaLabel,
-  className,
-  disabled = CODE_DEFAULTS.disabled,
-  skeleton = false,
-}) => {
-  const handleClick = useCallback(() => {
-    if (copyable && !disabled) {
-      onCopy?.();
+export const CodeInlineUi = memo(
+  forwardRef<HTMLElement, CodeInlineUiProps>(
+    (
+      {
+        children,
+        size = CODE_DEFAULTS.size,
+        copyable = CODE_DEFAULTS.copyable,
+        isCopied = false,
+        onCopy,
+        onKeyDown,
+        ariaLabel,
+        className,
+        disabled = CODE_DEFAULTS.disabled,
+        skeleton = false,
+      },
+      ref
+    ) => {
+      const handleClick = useCallback(() => {
+        if (copyable && !disabled) {
+          onCopy?.();
+        }
+      }, [copyable, disabled, onCopy]);
+
+      if (skeleton) {
+        return (
+          <Skeleton
+            variant="text"
+            width={size === 'lg' ? '120px' : size === 'sm' ? '60px' : '80px'}
+            height={size === 'lg' ? '1.5em' : '1em'}
+            className={className}
+            aria-busy="true"
+            data-skeleton="true"
+          />
+        );
+      }
+
+      const codeClassName = classNames(
+        styles.code,
+        styles[size],
+        copyable && !disabled && styles.copyable,
+        isCopied && styles.copied,
+        className
+      );
+
+      return (
+        <code
+          ref={ref}
+          className={codeClassName}
+          onClick={copyable && !disabled ? handleClick : undefined}
+          onKeyDown={copyable && !disabled ? onKeyDown : undefined}
+          tabIndex={copyable && !disabled ? 0 : undefined}
+          role={copyable && !disabled ? 'button' : undefined}
+          aria-label={ariaLabel || (copyable ? 'Click to copy code' : undefined)}
+          data-testid="code-inline"
+          data-size={size}
+          data-variant="inline"
+          aria-busy={skeleton || undefined}
+          data-skeleton={skeleton || undefined}
+        >
+          {children}
+        </code>
+      );
     }
-  }, [copyable, disabled, onCopy]);
+  )
+);
 
-  if (skeleton) {
-    return (
-      <Skeleton
-        variant="text"
-        width={size === 'lg' ? '120px' : size === 'sm' ? '60px' : '80px'}
-        height={size === 'lg' ? '1.5em' : '1em'}
-        className={className}
-        aria-busy="true"
-        data-skeleton="true"
-      />
-    );
-  }
-
-  const codeClassName = classNames(
-    styles.code,
-    styles[size],
-    copyable && !disabled && styles.copyable,
-    isCopied && styles.copied,
-    className
-  );
-
-  return (
-    <code
-      className={codeClassName}
-      onClick={copyable && !disabled ? handleClick : undefined}
-      onKeyDown={copyable && !disabled ? onKeyDown : undefined}
-      tabIndex={copyable && !disabled ? 0 : undefined}
-      role={copyable && !disabled ? 'button' : undefined}
-      aria-label={ariaLabel || (copyable ? 'Click to copy code' : undefined)}
-      data-testid="code-inline"
-      data-size={size}
-      data-variant="inline"
-      aria-busy={skeleton || undefined}
-      data-skeleton={skeleton || undefined}
-    >
-      {children}
-    </code>
-  );
-};
-
-CodeInlineUiInner.displayName = 'CodeInlineUi';
-
-export const CodeInlineUi = memo(CodeInlineUiInner);
-
-export default CodeInlineUi;
+CodeInlineUi.displayName = 'CodeInlineUi';


### PR DESCRIPTION
## Что сделано (P1 / SR1–SR3)
- **SR1** `Code` → `forwardRef<HTMLElement>`; ref пробрасывается к корню отрисованного варианта (`CodeInlineUi` = `<code>`, `CodeBlockUi` = `<div>`).
- **SR2** Публичное API `index.ts` сужено до `Code` + `useCopyCode` + типы. Убраны `CodeInlineUi`, `CodeBlockUi`, `CodeBlockHeader`, константы, `countLines`, `extractTextFromNode`.
- **SR3** Удалён `export default` во всех 7 исходниках (4 компонента + `useCopyCode` + `countLines` + `extractTextFromNode`).

## Проверки
- Внешних потребителей удалённых экспортов нет (`Hero.tsx` и `Popover.stories.tsx` берут `{ Code }` именованно).
- `npm run validate` зелёный: type-check + lint (0 warnings) + **2239 тестов** пройдены.

## Статус SR (issue #29)
- [x] SR1 forwardRef (HIGH)
- [x] SR2 public API cleanup (HIGH)
- [x] SR3 убрать export default ×7 (HIGH)
- [x] SR5 уже в коде (не требуется)
- [ ] SR4 Toast decoupling — P2
- [ ] SR6 единый CodeSkeleton — P2
- [ ] SR7 asChild — P3
- [ ] SR8 copyTimeout — P3

## Следующие шаги
- P2 (MEDIUM): SR4 (Toast decoupling через `onCopyResult` пропс) + SR6 (единый `CodeSkeleton`, DRY 3 копий).
- P3 (LOW): SR7 (`asChild`) + SR8 (`copyTimeout` пропс).

Refs #29
