### PR TITLE
refactor(code): add asChild (inline) and copyTimeout (SR7, SR8)

### DIFF
--- a/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
@@ -242,4 +242,48 @@ describe('useCopyCode', () => {
       expect(writeText).toHaveBeenCalledWith('const');
     });
   });
+
+  describe('copyTimeout', () => {
+    it('сбрасывает isCopied через таймаут по умолчанию (2000мс)', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      const { result } = renderHook(() => useCopyCode('test'));
+      await act(async () => {
+        result.current.handleCopy();
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1999);
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.isCopied).toBe(false);
+    });
+
+    it('уважает кастомный copyTimeout', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      const { result } = renderHook(() => useCopyCode('test', { copyTimeout: 500 }));
+      await act(async () => {
+        result.current.handleCopy();
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(499);
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.isCopied).toBe(false);
+    });
+  });
 });

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.ts
@@ -6,6 +6,8 @@ interface UseCopyCodeOptions {
   onCopyResult?: (success: boolean) => void;
   onCopy?: () => void;
   enabled?: boolean;
+  /** Таймаут сброса состояния isCopied, мс (по умолчанию 2000) */
+  copyTimeout?: number;
 }
 
 interface UseCopyCodeReturn {
@@ -32,7 +34,7 @@ export const useCopyCode = (
   code: React.ReactNode,
   options: UseCopyCodeOptions = {}
 ): UseCopyCodeReturn => {
-  const { onCopyResult, onCopy, enabled = true } = options;
+  const { onCopyResult, onCopy, enabled = true, copyTimeout = 2000 } = options;
 
   const [isCopied, setIsCopied] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -70,10 +72,10 @@ export const useCopyCode = (
 
     const timeoutId = setTimeout(() => {
       setIsCopied(false);
-    }, 2000);
+    }, copyTimeout);
 
     return () => clearTimeout(timeoutId);
-  }, [isCopied, enabled]);
+  }, [isCopied, enabled, copyTimeout]);
 
   const reset = useCallback(() => {
     setIsCopied(false);

--- a/src/shared/ui/Code/model/types.ts
+++ b/src/shared/ui/Code/model/types.ts
@@ -24,6 +24,8 @@ export interface CodeInlineProps {
   className?: string;
   /** Отключить копирование */
   disabled?: boolean;
+  /** Рендерить как дочерний элемент (Radix Slot pattern) */
+  asChild?: boolean;
 }
 
 export interface CodeBlockProps {
@@ -86,4 +88,8 @@ export interface CodeProps {
   copyButtonSize?: ButtonSize;
   /** Показывать скелетон загрузки */
   skeleton?: boolean;
+  /** Рендерить как дочерний элемент (Radix Slot pattern, только inline variant) */
+  asChild?: boolean;
+  /** Таймаут сброса состояния isCopied, мс (по умолчанию 2000) */
+  copyTimeout?: number;
 }

--- a/src/shared/ui/Code/ui/Code.tsx
+++ b/src/shared/ui/Code/ui/Code.tsx
@@ -13,12 +13,22 @@ import { CodeBlockUi } from './CodeBlock/CodeBlock';
  */
 export const Code = forwardRef<HTMLElement, CodeProps>(
   (
-    { children, variant = CODE_DEFAULTS.variant, onCopy, onCopyResult, skeleton = false, ...props },
+    {
+      children,
+      variant = CODE_DEFAULTS.variant,
+      onCopy,
+      onCopyResult,
+      skeleton = false,
+      asChild,
+      copyTimeout,
+      ...props
+    },
     ref
   ) => {
     const { isCopied, handleCopy } = useCopyCode(children, {
       onCopyResult,
       onCopy,
+      copyTimeout,
       enabled: !skeleton,
     });
 
@@ -58,6 +68,7 @@ export const Code = forwardRef<HTMLElement, CodeProps>(
         <CodeInlineUi
           {...props}
           ref={ref}
+          asChild={asChild}
           isCopied={isCopied}
           onCopy={handleCopy}
           onKeyDown={handleKeyDown}

--- a/src/shared/ui/Code/ui/CodeInlineUi.test.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.test.tsx
@@ -205,4 +205,59 @@ describe('CodeInlineUi', () => {
       expect(skeleton).toHaveAttribute('aria-busy', 'true');
     });
   });
+
+  describe('asChild', () => {
+    it('должен рендерить предоставленный дочерний элемент вместо <code>', () => {
+      render(
+        <CodeInlineUi asChild>
+          <span>const x = 10;</span>
+        </CodeInlineUi>
+      );
+
+      const el = screen.getByTestId('code-inline');
+      expect(el.tagName).toBe('SPAN');
+      expect(el).toHaveTextContent('const x = 10;');
+    });
+
+    it('должен мержить code-классы и кастомный className в дочерний элемент', () => {
+      const { container } = render(
+        <CodeInlineUi asChild className="custom-class">
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      const el = container.querySelector('span');
+      expect(el).toHaveClass(styles.code ?? '');
+      expect(el).toHaveClass('custom-class');
+    });
+
+    it('должен вызывать onCopy при клике на дочерний элемент (copyable)', () => {
+      const handleCopy = vi.fn();
+      render(
+        <CodeInlineUi asChild copyable onCopy={handleCopy}>
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      fireEvent.click(screen.getByTestId('code-inline'));
+      expect(handleCopy).toHaveBeenCalledTimes(1);
+    });
+
+    it('должен иметь role="button" и tabIndex при copyable', () => {
+      render(
+        <CodeInlineUi asChild copyable>
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      const el = screen.getByTestId('code-inline');
+      expect(el).toHaveAttribute('role', 'button');
+      expect(el).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('должен возвращать null при asChild без валидного дочернего элемента', () => {
+      const { container } = render(<CodeInlineUi asChild>{'plain text'}</CodeInlineUi>);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -1,7 +1,7 @@
 // src/shared/ui/Code/ui/CodeInlineUi.tsx
 
 import { classNames } from '@/shared/lib/utils/classNames';
-import { forwardRef, memo, useCallback } from 'react';
+import { cloneElement, forwardRef, isValidElement, memo, useCallback } from 'react';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
 import { CodeSkeleton } from './CodeSkeleton/CodeSkeleton';
@@ -37,6 +37,7 @@ export const CodeInlineUi = memo(
         className,
         disabled = CODE_DEFAULTS.disabled,
         skeleton = false,
+        asChild = false,
       },
       ref
     ) => {
@@ -57,6 +58,31 @@ export const CodeInlineUi = memo(
         isCopied && styles.copied,
         className
       );
+
+      // asChild: клонируем единственного дочернего ReactElement (Radix Slot pattern),
+      // мержим стили/attrs/обработчики копирования (как Button.asChild)
+      if (asChild) {
+        if (!isValidElement(children)) {
+          return null;
+        }
+        const child = children as React.ReactElement;
+        const childProps = child.props as Record<string, unknown>;
+        const cloned = cloneElement(child, {
+          className: classNames(codeClassName, childProps.className as string | undefined),
+          onClick: copyable && !disabled ? handleClick : undefined,
+          onKeyDown: copyable && !disabled ? onKeyDown : undefined,
+          tabIndex: copyable && !disabled ? 0 : undefined,
+          role: copyable && !disabled ? 'button' : undefined,
+          'aria-label': ariaLabel || (copyable ? 'Click to copy code' : undefined),
+          'data-testid': 'code-inline',
+          'data-size': size,
+          'data-variant': 'inline',
+          'data-skeleton': skeleton || undefined,
+          'aria-busy': skeleton || undefined,
+          ref,
+        } as Record<string, unknown>);
+        return cloned as React.ReactElement;
+      }
 
       return (
         <code


### PR DESCRIPTION
## Что сделано (P3 эпика #29)

### SR7 — asChild (inline variant)
- `CodeInlineUi`: добавлен пропс `asChild`. При `asChild` компонент клонирует единственный дочерний ReactElement через `cloneElement` (Radix Slot pattern, как `Button.asChild`) и мержит code-стили, `data-*`, `aria-*` и обработчики копирования в предоставленный элемент.
- `CodeProps`/`CodeInlineProps`: добавлен `asChild` (проброшен в `CodeInlineUi` только для inline-варианта).
- Не-элементный child при `asChild` → `null` (defensive).

### SR8 — copyTimeout
- `useCopyCode`: добавлена опция `copyTimeout` (default 2000), заменяет захардкоженный `setTimeout(..., 2000)`.
- `CodeProps`: добавлен `copyTimeout?: number`, проброшен в хук.

### Проверка
- `npm run validate` — green (type-check, eslint --max-warnings 0, stylelint, vitest + coverage).
- Тесты: `useCopyCode.test.ts` (copyTimeout), `CodeInlineUi.test.tsx` (asChild) добавлены.

База: `dev` (STRICT dev-trunk). Мерж только после явного аппрува.

Closes part of #29