### PR TITLE
refactor(code): fix review findings — i18n Hero copy and compose asChild handlers

### DIFF
--- a/src/features/Hero/ui/Hero.tsx
+++ b/src/features/Hero/ui/Hero.tsx
@@ -65,7 +65,7 @@ export const Hero: React.FC<HeroProps> = ({
             className={styles.codeBlock}
             onCopyResult={(success) =>
               addToast({
-                message: success ? 'Code copied to clipboard' : 'Failed to copy code',
+                message: success ? t(`codeCopied`) : t(`codeCopyFailed`),
                 type: success ? 'success' : 'error',
                 duration: success ? 2000 : 3000,
               })

--- a/src/shared/lib/i18n/locales/en.json
+++ b/src/shared/lib/i18n/locales/en.json
@@ -54,5 +54,7 @@
   "imageAltPortrait": "Portrait photo",
   "imageAltLandscape": "Landscape image",
   "imageAltProduct": "Product image",
-  "imageAltIcon": "Icon"
+  "imageAltIcon": "Icon",
+  "codeCopied": "Code copied to clipboard",
+  "codeCopyFailed": "Failed to copy code"
 }

--- a/src/shared/lib/i18n/locales/ru.json
+++ b/src/shared/lib/i18n/locales/ru.json
@@ -54,5 +54,7 @@
   "imageAltPortrait": "Портретное фото",
   "imageAltLandscape": "Пейзажное изображение",
   "imageAltProduct": "Изображение продукта",
-  "imageAltIcon": "Иконка"
+  "imageAltIcon": "Иконка",
+  "codeCopied": "Код скопирован в буфер обмена",
+  "codeCopyFailed": "Не удалось скопировать код"
 }

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -1,6 +1,7 @@
 // src/shared/ui/Code/ui/CodeInlineUi.tsx
 
 import { classNames } from '@/shared/lib/utils/classNames';
+import { mergeRefs } from '@/shared/lib/utils/mergeRefs';
 import { cloneElement, forwardRef, isValidElement, memo, useCallback } from 'react';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
@@ -60,26 +61,35 @@ export const CodeInlineUi = memo(
       );
 
       // asChild: клонируем единственного дочернего ReactElement (Radix Slot pattern),
-      // мержим стили/attrs/обработчики копирования (как Button.asChild)
+      // КОМПОНУЕМ (не перезаписываем) обработчики и ref ребёнка с логикой копирования —
+      // иначе интерактивный дочерний элемент теряет свои onClick/onKeyDown/ref.
       if (asChild) {
         if (!isValidElement(children)) {
           return null;
         }
         const child = children as React.ReactElement;
         const childProps = child.props as Record<string, unknown>;
+        const childRef = (child as { ref?: React.Ref<HTMLElement> }).ref;
+        const childOnClick = childProps.onClick as ((e: React.MouseEvent) => void) | undefined;
+        const childOnKeyDown = childProps.onKeyDown as
+          ((e: React.KeyboardEvent) => void) | undefined;
         const cloned = cloneElement(child, {
           className: classNames(codeClassName, childProps.className as string | undefined),
-          onClick: copyable && !disabled ? handleClick : undefined,
-          onKeyDown: copyable && !disabled ? onKeyDown : undefined,
+          onClick: (e: React.MouseEvent) => {
+            childOnClick?.(e);
+            if (copyable && !disabled) handleClick();
+          },
+          onKeyDown: (e: React.KeyboardEvent) => {
+            childOnKeyDown?.(e);
+            if (copyable && !disabled) onKeyDown?.(e);
+          },
           tabIndex: copyable && !disabled ? 0 : undefined,
           role: copyable && !disabled ? 'button' : undefined,
           'aria-label': ariaLabel || (copyable ? 'Click to copy code' : undefined),
           'data-testid': 'code-inline',
           'data-size': size,
           'data-variant': 'inline',
-          'data-skeleton': skeleton || undefined,
-          'aria-busy': skeleton || undefined,
-          ref,
+          ref: mergeRefs(childRef as React.Ref<HTMLElement>, ref as React.Ref<HTMLElement>),
         } as Record<string, unknown>);
         return cloned as React.ReactElement;
       }


### PR DESCRIPTION
## Что исправлено (findings глубокого кодревью)

### Standards (HARD)
- `Hero.tsx`: hardcoded toast-строки `'Code copied to clipboard'` / `'Failed to copy code'` → `t('codeCopied')` / `t('codeCopyFailed')` (CONTRIBUTING.md:45). Ключи добавлены в `en.json` / `ru.json`.

### Spec (SR7)
- `CodeInlineUi.tsx` asChild: теперь КОМПОНУЕТ обработчики/ref ребёнка (`onClick`/`onKeyDown`/`ref`) с логикой копирования через `mergeRefs`, вместо перезаписи (ранее интерактивный дочерний элемент терял свои хендлеры/ref). Убраны мёртвые `data-skeleton`/`aria-busy` в asChild-ветке.

Связано с issue #29 (P2/P3). База: `dev`.