### PR TITLE
release: shared/ui/Code Senior+ (SR1–SR8) → main

### DIFF
--- a/src/features/Hero/ui/Hero.test.tsx
+++ b/src/features/Hero/ui/Hero.test.tsx
@@ -7,6 +7,11 @@ vi.mock('@/shared/lib/i18n/hooks', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
 }));
 
+// Code теперь decoupled от Toast; Hero подключает тост через useToast — даём no-op
+vi.mock('@/shared/lib/contexts/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
 // Visual leaf components that are not the integration target — keep the test
 // focused on the Link CTA wiring.
 vi.mock('@/shared/ui/Code', () => ({

--- a/src/features/Hero/ui/Hero.tsx
+++ b/src/features/Hero/ui/Hero.tsx
@@ -65,7 +65,7 @@ export const Hero: React.FC<HeroProps> = ({
             className={styles.codeBlock}
             onCopyResult={(success) =>
               addToast({
-                message: success ? 'Code copied to clipboard' : 'Failed to copy code',
+                message: success ? t(`codeCopied`) : t(`codeCopyFailed`),
                 type: success ? 'success' : 'error',
                 duration: success ? 2000 : 3000,
               })

--- a/src/features/Hero/ui/Hero.tsx
+++ b/src/features/Hero/ui/Hero.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/shared/lib/i18n/hooks';
 const avatarImage = '/images/avatar/avatar003.jpg';
 import { Code } from '@/shared/ui/Code';
 import { Link } from '@/shared/ui/Link';
+import { useToast } from '@/shared/lib/contexts/ToastContext';
 import React, { useEffect, useState } from 'react';
 import { HeroProps } from '../model/types';
 import styles from './Hero.module.scss';
@@ -25,6 +26,7 @@ export const Hero: React.FC<HeroProps> = ({
   'data-testid': testId = 'hero',
 }) => {
   const { t } = useLanguage();
+  const { addToast } = useToast();
   const [avatarState, setAvatarState] = useState<AvatarState>('loading');
 
   // Имитация загрузки аватара (для демонстрации состояний)
@@ -61,6 +63,13 @@ export const Hero: React.FC<HeroProps> = ({
             copyable
             showLineNumbers
             className={styles.codeBlock}
+            onCopyResult={(success) =>
+              addToast({
+                message: success ? 'Code copied to clipboard' : 'Failed to copy code',
+                type: success ? 'success' : 'error',
+                duration: success ? 2000 : 3000,
+              })
+            }
           >
             <SkillsCode />
           </Code>

--- a/src/shared/lib/i18n/locales/en.json
+++ b/src/shared/lib/i18n/locales/en.json
@@ -54,5 +54,7 @@
   "imageAltPortrait": "Portrait photo",
   "imageAltLandscape": "Landscape image",
   "imageAltProduct": "Product image",
-  "imageAltIcon": "Icon"
+  "imageAltIcon": "Icon",
+  "codeCopied": "Code copied to clipboard",
+  "codeCopyFailed": "Failed to copy code"
 }

--- a/src/shared/lib/i18n/locales/ru.json
+++ b/src/shared/lib/i18n/locales/ru.json
@@ -54,5 +54,7 @@
   "imageAltPortrait": "Портретное фото",
   "imageAltLandscape": "Пейзажное изображение",
   "imageAltProduct": "Изображение продукта",
-  "imageAltIcon": "Иконка"
+  "imageAltIcon": "Иконка",
+  "codeCopied": "Код скопирован в буфер обмена",
+  "codeCopyFailed": "Не удалось скопировать код"
 }

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
@@ -242,4 +242,48 @@ describe('useCopyCode', () => {
       expect(writeText).toHaveBeenCalledWith('const');
     });
   });
+
+  describe('copyTimeout', () => {
+    it('сбрасывает isCopied через таймаут по умолчанию (2000мс)', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      const { result } = renderHook(() => useCopyCode('test'));
+      await act(async () => {
+        result.current.handleCopy();
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1999);
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.isCopied).toBe(false);
+    });
+
+    it('уважает кастомный copyTimeout', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      const { result } = renderHook(() => useCopyCode('test', { copyTimeout: 500 }));
+      await act(async () => {
+        result.current.handleCopy();
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(499);
+      });
+      expect(result.current.isCopied).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.isCopied).toBe(false);
+    });
+  });
 });

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.test.ts
@@ -123,47 +123,47 @@ describe('useCopyCode', () => {
     });
   });
 
-  describe('options — addToast', () => {
-    it('вызывает addToast при showToastOnSuccess=true', () => {
+  describe('options — onCopyResult', () => {
+    it('вызывает onCopyResult(true) при успешном копировании', () => {
       const writeText = vi.fn().mockResolvedValue(undefined);
       Object.assign(navigator, { clipboard: { writeText } });
-      const addToast = vi.fn();
+      const onCopyResult = vi.fn();
 
-      const { result } = renderHook(() =>
-        useCopyCode('test', { showToastOnSuccess: true, addToast })
-      );
+      const { result } = renderHook(() => useCopyCode('test', { onCopyResult }));
       act(() => {
         result.current.handleCopy();
       });
 
       return vi.waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith({
-          message: 'Code copied to clipboard',
-          type: 'success',
-          duration: 2000,
-        });
+        expect(onCopyResult).toHaveBeenCalledWith(true);
       });
     });
 
-    it('вызывает addToast при showToastOnError=true', () => {
+    it('вызывает onCopyResult(false) при ошибке clipboard', () => {
       const writeText = vi.fn().mockRejectedValue(new Error('fail'));
       Object.assign(navigator, { clipboard: { writeText } });
-      const addToast = vi.fn();
+      const onCopyResult = vi.fn();
 
-      const { result } = renderHook(() =>
-        useCopyCode('test', { showToastOnError: true, addToast })
-      );
+      const { result } = renderHook(() => useCopyCode('test', { onCopyResult }));
       act(() => {
         result.current.handleCopy();
       });
 
       return vi.waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith({
-          message: 'Failed to copy code',
-          type: 'error',
-          duration: 3000,
-        });
+        expect(onCopyResult).toHaveBeenCalledWith(false);
       });
+    });
+
+    it('вызывает onCopyResult(false) когда clipboard = undefined', () => {
+      Object.assign(navigator, { clipboard: undefined });
+      const onCopyResult = vi.fn();
+
+      const { result } = renderHook(() => useCopyCode('test', { onCopyResult }));
+      act(() => {
+        result.current.handleCopy();
+      });
+
+      expect(onCopyResult).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.ts
@@ -1,11 +1,9 @@
-import type { ToastOptions } from '@/shared/ui/Toast/model/types';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { extractTextFromNode } from '../utils/extractTextFromNode';
 
 interface UseCopyCodeOptions {
-  showToastOnSuccess?: boolean;
-  showToastOnError?: boolean;
-  addToast?: (options: ToastOptions) => void;
+  /** Результат копирования: true — успех, false — ошибка. Тост/уведомление решает consumer (IoC) */
+  onCopyResult?: (success: boolean) => void;
   onCopy?: () => void;
   enabled?: boolean;
 }
@@ -23,21 +21,18 @@ interface UseCopyCodeReturn {
  * Использует `navigator.clipboard.writeText()` синхронно в обработчике клика,
  * без async/await, чтобы не терять user gesture (transient activation).
  *
+ * Хук НЕ зависит от UI/Toast — результат копирования сообщается через `onCopyResult`,
+ * а отображение тоста (или иное поведение) решает вызывающая сторона.
+ *
  * @param code - React-узел для извлечения текста
- * @param options - Опции: тосты, колбэки
+ * @param options - Опции: колбэк результата, колбэк копирования
  * @returns Объект с состояниями и обработчиками копирования
  */
 export const useCopyCode = (
   code: React.ReactNode,
   options: UseCopyCodeOptions = {}
 ): UseCopyCodeReturn => {
-  const {
-    showToastOnSuccess = false,
-    showToastOnError = true,
-    addToast,
-    onCopy,
-    enabled = true,
-  } = options;
+  const { onCopyResult, onCopy, enabled = true } = options;
 
   const [isCopied, setIsCopied] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -52,11 +47,7 @@ export const useCopyCode = (
 
     if (!navigator.clipboard) {
       setIsError(true);
-
-      if (showToastOnError && addToast) {
-        addToast({ message: 'Failed to copy code', type: 'error', duration: 3000 });
-      }
-
+      onCopyResult?.(false);
       return;
     }
 
@@ -64,23 +55,14 @@ export const useCopyCode = (
       .writeText(codeText)
       .then(() => {
         setIsCopied(true);
-
-        if (showToastOnSuccess && addToast) {
-          addToast({ message: 'Code copied to clipboard', type: 'success', duration: 2000 });
-        }
-
+        onCopyResult?.(true);
         onCopy?.();
-
-        // Таймаут сброса обрабатывается в useEffect для cleanup при unmount
       })
       .catch(() => {
         setIsError(true);
-
-        if (showToastOnError && addToast) {
-          addToast({ message: 'Failed to copy code', type: 'error', duration: 3000 });
-        }
+        onCopyResult?.(false);
       });
-  }, [codeText, showToastOnSuccess, showToastOnError, addToast, onCopy, enabled]);
+  }, [codeText, onCopyResult, onCopy, enabled]);
 
   // Cleanup таймаута при размонтировании или изменении isCopied
   useEffect(() => {

--- a/src/shared/ui/Code/lib/hooks/useCopyCode.ts
+++ b/src/shared/ui/Code/lib/hooks/useCopyCode.ts
@@ -6,6 +6,8 @@ interface UseCopyCodeOptions {
   onCopyResult?: (success: boolean) => void;
   onCopy?: () => void;
   enabled?: boolean;
+  /** Таймаут сброса состояния isCopied, мс (по умолчанию 2000) */
+  copyTimeout?: number;
 }
 
 interface UseCopyCodeReturn {
@@ -32,7 +34,7 @@ export const useCopyCode = (
   code: React.ReactNode,
   options: UseCopyCodeOptions = {}
 ): UseCopyCodeReturn => {
-  const { onCopyResult, onCopy, enabled = true } = options;
+  const { onCopyResult, onCopy, enabled = true, copyTimeout = 2000 } = options;
 
   const [isCopied, setIsCopied] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -70,10 +72,10 @@ export const useCopyCode = (
 
     const timeoutId = setTimeout(() => {
       setIsCopied(false);
-    }, 2000);
+    }, copyTimeout);
 
     return () => clearTimeout(timeoutId);
-  }, [isCopied, enabled]);
+  }, [isCopied, enabled, copyTimeout]);
 
   const reset = useCallback(() => {
     setIsCopied(false);

--- a/src/shared/ui/Code/model/types.ts
+++ b/src/shared/ui/Code/model/types.ts
@@ -24,6 +24,8 @@ export interface CodeInlineProps {
   className?: string;
   /** Отключить копирование */
   disabled?: boolean;
+  /** Рендерить как дочерний элемент (Radix Slot pattern) */
+  asChild?: boolean;
 }
 
 export interface CodeBlockProps {
@@ -86,4 +88,8 @@ export interface CodeProps {
   copyButtonSize?: ButtonSize;
   /** Показывать скелетон загрузки */
   skeleton?: boolean;
+  /** Рендерить как дочерний элемент (Radix Slot pattern, только inline variant) */
+  asChild?: boolean;
+  /** Таймаут сброса состояния isCopied, мс (по умолчанию 2000) */
+  copyTimeout?: number;
 }

--- a/src/shared/ui/Code/model/types.ts
+++ b/src/shared/ui/Code/model/types.ts
@@ -4,14 +4,7 @@ import type { LucideIcon } from 'lucide-react';
 export type CodeSize = 'sm' | 'md' | 'lg';
 export type CodeVariant = 'inline' | 'block';
 export type CodeLanguage =
-  | 'typescript'
-  | 'javascript'
-  | 'css'
-  | 'html'
-  | 'json'
-  | 'bash'
-  | 'python'
-  | string;
+  'typescript' | 'javascript' | 'css' | 'html' | 'json' | 'bash' | 'python' | string;
 
 export interface CodeIcons {
   /** Иконка копирования */
@@ -81,6 +74,8 @@ export interface CodeProps {
   title?: string;
   /** Callback при копировании */
   onCopy?: () => void;
+  /** Результат копирования: true — успех, false — ошибка. Тост/уведомление решает consumer (Inversion of Control) */
+  onCopyResult?: (success: boolean) => void;
   /** Отключить копирование */
   disabled?: boolean;
   /** Accessibility label */

--- a/src/shared/ui/Code/ui/Code.test.tsx
+++ b/src/shared/ui/Code/ui/Code.test.tsx
@@ -2,12 +2,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Code } from './Code';
 
-// Mock useToast
-const mockAddToast = vi.fn();
-vi.mock('@/shared/lib/contexts/ToastContext', () => ({
-  useToast: () => ({ addToast: mockAddToast }),
-}));
-
 // Mock navigator.clipboard
 const mockWriteText = vi.fn();
 beforeEach(() => {
@@ -161,10 +155,11 @@ describe('Code (Integration)', () => {
       });
     });
 
-    it('должен добавлять toast при успешном копировании', async () => {
+    it('должен вызывать onCopyResult(true) при успешном копировании', async () => {
       mockWriteText.mockResolvedValue(undefined);
+      const onCopyResult = vi.fn();
       render(
-        <Code variant="inline" copyable>
+        <Code variant="inline" copyable onCopyResult={onCopyResult}>
           npm install
         </Code>
       );
@@ -172,11 +167,7 @@ describe('Code (Integration)', () => {
       fireEvent.click(screen.getByTestId('code-inline'));
 
       await vi.waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith({
-          message: 'Code copied to clipboard',
-          type: 'success',
-          duration: 2000,
-        });
+        expect(onCopyResult).toHaveBeenCalledWith(true);
       });
     });
 

--- a/src/shared/ui/Code/ui/Code.tsx
+++ b/src/shared/ui/Code/ui/Code.tsx
@@ -1,4 +1,3 @@
-import { useToast } from '@/shared/lib/contexts/ToastContext';
 import { forwardRef, useCallback } from 'react';
 import type { CodeProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
@@ -13,13 +12,12 @@ import { CodeBlockUi } from './CodeBlock/CodeBlock';
  * Поддерживает skeleton-режим для состояния загрузки.
  */
 export const Code = forwardRef<HTMLElement, CodeProps>(
-  ({ children, variant = CODE_DEFAULTS.variant, onCopy, skeleton = false, ...props }, ref) => {
-    const { addToast } = useToast();
-
+  (
+    { children, variant = CODE_DEFAULTS.variant, onCopy, onCopyResult, skeleton = false, ...props },
+    ref
+  ) => {
     const { isCopied, handleCopy } = useCopyCode(children, {
-      addToast,
-      showToastOnSuccess: true,
-      showToastOnError: true,
+      onCopyResult,
       onCopy,
       enabled: !skeleton,
     });

--- a/src/shared/ui/Code/ui/Code.tsx
+++ b/src/shared/ui/Code/ui/Code.tsx
@@ -13,12 +13,22 @@ import { CodeBlockUi } from './CodeBlock/CodeBlock';
  */
 export const Code = forwardRef<HTMLElement, CodeProps>(
   (
-    { children, variant = CODE_DEFAULTS.variant, onCopy, onCopyResult, skeleton = false, ...props },
+    {
+      children,
+      variant = CODE_DEFAULTS.variant,
+      onCopy,
+      onCopyResult,
+      skeleton = false,
+      asChild,
+      copyTimeout,
+      ...props
+    },
     ref
   ) => {
     const { isCopied, handleCopy } = useCopyCode(children, {
       onCopyResult,
       onCopy,
+      copyTimeout,
       enabled: !skeleton,
     });
 
@@ -58,6 +68,7 @@ export const Code = forwardRef<HTMLElement, CodeProps>(
         <CodeInlineUi
           {...props}
           ref={ref}
+          asChild={asChild}
           isCopied={isCopied}
           onCopy={handleCopy}
           onKeyDown={handleKeyDown}

--- a/src/shared/ui/Code/ui/CodeBlock/CodeBlock.tsx
+++ b/src/shared/ui/Code/ui/CodeBlock/CodeBlock.tsx
@@ -1,10 +1,10 @@
 import { classNames } from '@/shared/lib/utils/classNames';
 import { forwardRef, memo, useMemo } from 'react';
-import { Skeleton } from '@/shared/ui/Skeleton';
 import type { CodeBlockProps } from '../../model/types';
 import { CODE_DEFAULTS } from '../../model/constants';
 import { countLines } from '../../lib/utils/countLines';
 import { CodeBlockHeader } from '../CodeBlockHeader/CodeBlockHeader';
+import { CodeSkeleton } from '../CodeSkeleton/CodeSkeleton';
 import styles from './CodeBlock.module.scss';
 
 export interface CodeBlockUiProps extends CodeBlockProps {
@@ -67,23 +67,7 @@ export const CodeBlockUi = memo(
             data-skeleton="true"
             aria-busy="true"
           >
-            <CodeBlockHeader
-              language={language}
-              title={title}
-              copyable={copyable}
-              icons={icons}
-              copyButtonSize={copyButtonSize}
-              skeleton
-            />
-            <div className={styles.blockContent}>
-              <Skeleton
-                variant="rectangular"
-                width="100%"
-                height={maxHeight || '310px'}
-                aria-busy="true"
-                data-skeleton="true"
-              />
-            </div>
+            <CodeSkeleton variant="block" language={language} title={title} copyable={copyable} />
           </div>
         );
       }

--- a/src/shared/ui/Code/ui/CodeBlockHeader/CodeBlockHeader.tsx
+++ b/src/shared/ui/Code/ui/CodeBlockHeader/CodeBlockHeader.tsx
@@ -4,7 +4,6 @@ import { ButtonWithIcon } from '@/shared/ui/Button';
 import type { ButtonSize } from '@/shared/ui/Button/model/types';
 import { Check, Copy } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { Skeleton } from '@/shared/ui/Skeleton';
 import { Icon } from '@/shared/ui/Icon';
 import type { CodeLanguage } from '../../model/types';
 import styles from './CodeBlockHeader.module.scss';
@@ -33,8 +32,6 @@ export interface CodeBlockHeaderProps {
   copyButtonSize?: ButtonSize;
   /** Дополнительный класс */
   className?: string;
-  /** Скелетон режим */
-  skeleton?: boolean;
 }
 
 /**
@@ -51,7 +48,6 @@ export interface CodeBlockHeaderProps {
  * @param icons - Кастомные иконки copy/copied
  * @param copyButtonSize - Размер кнопки копирования
  * @param className - Дополнительный CSS-класс
- * @param skeleton - Показывать скелетон загрузки
  */
 const CodeBlockHeaderInner: React.FC<CodeBlockHeaderProps> = ({
   language,
@@ -64,7 +60,6 @@ const CodeBlockHeaderInner: React.FC<CodeBlockHeaderProps> = ({
   icons,
   copyButtonSize = 'sm',
   className,
-  skeleton = false,
 }) => {
   const CopyIcon = icons?.copy ?? Copy;
   const CopiedIcon = icons?.copied ?? Check;
@@ -80,59 +75,35 @@ const CodeBlockHeaderInner: React.FC<CodeBlockHeaderProps> = ({
         </div>
 
         {/* Language & Title */}
-        {skeleton ? (
-          <div className={styles.blockTitleSkeleton}>
-            {language && (
-              <Skeleton
-                variant="text"
-                width="36px"
-                height="0.75rem"
-                className={styles.languageSkeleton}
-              />
-            )}
-            {title && <Skeleton variant="text" width="120px" height="0.875rem" />}
+        {title && (
+          <div className={styles.blockTitle}>
+            {language && <span className={styles.language}>{language}</span>}
+            {title}
           </div>
-        ) : (
-          title && (
-            <div className={styles.blockTitle}>
-              {language && <span className={styles.language}>{language}</span>}
-              {title}
-            </div>
-          )
         )}
       </div>
 
       {/* Copy button */}
-      {skeleton
-        ? copyable && (
-            <Skeleton
-              variant="rectangular"
-              width="64px"
-              height="28px"
-              className={styles.copyButtonSkeleton}
-            />
-          )
-        : copyable &&
-          !disabled && (
-            <ButtonWithIcon
-              variant="ghost"
-              size={copyButtonSize}
-              leftIcon={
-                isCopied ? (
-                  <Icon name={CopiedIcon} size={14} color="inherit" decorative />
-                ) : (
-                  <Icon name={CopyIcon} size={14} color="inherit" decorative />
-                )
-              }
-              onClick={onCopy}
-              onKeyDown={onKeyDown}
-              aria-label={isCopied ? 'Copied!' : 'Copy code'}
-              data-testid="code-copy-button"
-              className={classNames(styles.copyButton, isCopied && styles.copied)}
-            >
-              {isCopied ? 'Copied!' : 'Copy'}
-            </ButtonWithIcon>
-          )}
+      {copyable && !disabled && (
+        <ButtonWithIcon
+          variant="ghost"
+          size={copyButtonSize}
+          leftIcon={
+            isCopied ? (
+              <Icon name={CopiedIcon} size={14} color="inherit" decorative />
+            ) : (
+              <Icon name={CopyIcon} size={14} color="inherit" decorative />
+            )
+          }
+          onClick={onCopy}
+          onKeyDown={onKeyDown}
+          aria-label={isCopied ? 'Copied!' : 'Copy code'}
+          data-testid="code-copy-button"
+          className={classNames(styles.copyButton, isCopied && styles.copied)}
+        >
+          {isCopied ? 'Copied!' : 'Copy'}
+        </ButtonWithIcon>
+      )}
     </div>
   );
 };

--- a/src/shared/ui/Code/ui/CodeInlineUi.test.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.test.tsx
@@ -205,4 +205,59 @@ describe('CodeInlineUi', () => {
       expect(skeleton).toHaveAttribute('aria-busy', 'true');
     });
   });
+
+  describe('asChild', () => {
+    it('должен рендерить предоставленный дочерний элемент вместо <code>', () => {
+      render(
+        <CodeInlineUi asChild>
+          <span>const x = 10;</span>
+        </CodeInlineUi>
+      );
+
+      const el = screen.getByTestId('code-inline');
+      expect(el.tagName).toBe('SPAN');
+      expect(el).toHaveTextContent('const x = 10;');
+    });
+
+    it('должен мержить code-классы и кастомный className в дочерний элемент', () => {
+      const { container } = render(
+        <CodeInlineUi asChild className="custom-class">
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      const el = container.querySelector('span');
+      expect(el).toHaveClass(styles.code ?? '');
+      expect(el).toHaveClass('custom-class');
+    });
+
+    it('должен вызывать onCopy при клике на дочерний элемент (copyable)', () => {
+      const handleCopy = vi.fn();
+      render(
+        <CodeInlineUi asChild copyable onCopy={handleCopy}>
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      fireEvent.click(screen.getByTestId('code-inline'));
+      expect(handleCopy).toHaveBeenCalledTimes(1);
+    });
+
+    it('должен иметь role="button" и tabIndex при copyable', () => {
+      render(
+        <CodeInlineUi asChild copyable>
+          <span>code</span>
+        </CodeInlineUi>
+      );
+
+      const el = screen.getByTestId('code-inline');
+      expect(el).toHaveAttribute('role', 'button');
+      expect(el).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('должен возвращать null при asChild без валидного дочернего элемента', () => {
+      const { container } = render(<CodeInlineUi asChild>{'plain text'}</CodeInlineUi>);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -1,6 +1,7 @@
 // src/shared/ui/Code/ui/CodeInlineUi.tsx
 
 import { classNames } from '@/shared/lib/utils/classNames';
+import { mergeRefs } from '@/shared/lib/utils/mergeRefs';
 import { cloneElement, forwardRef, isValidElement, memo, useCallback } from 'react';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
@@ -60,26 +61,35 @@ export const CodeInlineUi = memo(
       );
 
       // asChild: клонируем единственного дочернего ReactElement (Radix Slot pattern),
-      // мержим стили/attrs/обработчики копирования (как Button.asChild)
+      // КОМПОНУЕМ (не перезаписываем) обработчики и ref ребёнка с логикой копирования —
+      // иначе интерактивный дочерний элемент теряет свои onClick/onKeyDown/ref.
       if (asChild) {
         if (!isValidElement(children)) {
           return null;
         }
         const child = children as React.ReactElement;
         const childProps = child.props as Record<string, unknown>;
+        const childRef = (child as { ref?: React.Ref<HTMLElement> }).ref;
+        const childOnClick = childProps.onClick as ((e: React.MouseEvent) => void) | undefined;
+        const childOnKeyDown = childProps.onKeyDown as
+          ((e: React.KeyboardEvent) => void) | undefined;
         const cloned = cloneElement(child, {
           className: classNames(codeClassName, childProps.className as string | undefined),
-          onClick: copyable && !disabled ? handleClick : undefined,
-          onKeyDown: copyable && !disabled ? onKeyDown : undefined,
+          onClick: (e: React.MouseEvent) => {
+            childOnClick?.(e);
+            if (copyable && !disabled) handleClick();
+          },
+          onKeyDown: (e: React.KeyboardEvent) => {
+            childOnKeyDown?.(e);
+            if (copyable && !disabled) onKeyDown?.(e);
+          },
           tabIndex: copyable && !disabled ? 0 : undefined,
           role: copyable && !disabled ? 'button' : undefined,
           'aria-label': ariaLabel || (copyable ? 'Click to copy code' : undefined),
           'data-testid': 'code-inline',
           'data-size': size,
           'data-variant': 'inline',
-          'data-skeleton': skeleton || undefined,
-          'aria-busy': skeleton || undefined,
-          ref,
+          ref: mergeRefs(childRef as React.Ref<HTMLElement>, ref as React.Ref<HTMLElement>),
         } as Record<string, unknown>);
         return cloned as React.ReactElement;
       }

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -2,9 +2,9 @@
 
 import { classNames } from '@/shared/lib/utils/classNames';
 import { forwardRef, memo, useCallback } from 'react';
-import { Skeleton } from '@/shared/ui/Skeleton';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
+import { CodeSkeleton } from './CodeSkeleton/CodeSkeleton';
 import styles from './CodeInlineUi.module.scss';
 
 export interface CodeInlineUiProps extends CodeInlineProps {
@@ -47,16 +47,7 @@ export const CodeInlineUi = memo(
       }, [copyable, disabled, onCopy]);
 
       if (skeleton) {
-        return (
-          <Skeleton
-            variant="text"
-            width={size === 'lg' ? '120px' : size === 'sm' ? '60px' : '80px'}
-            height={size === 'lg' ? '1.5em' : '1em'}
-            className={className}
-            aria-busy="true"
-            data-skeleton="true"
-          />
-        );
+        return <CodeSkeleton variant="inline" size={size} className={className} />;
       }
 
       const codeClassName = classNames(

--- a/src/shared/ui/Code/ui/CodeInlineUi.tsx
+++ b/src/shared/ui/Code/ui/CodeInlineUi.tsx
@@ -1,7 +1,7 @@
 // src/shared/ui/Code/ui/CodeInlineUi.tsx
 
 import { classNames } from '@/shared/lib/utils/classNames';
-import { forwardRef, memo, useCallback } from 'react';
+import { cloneElement, forwardRef, isValidElement, memo, useCallback } from 'react';
 import type { CodeInlineProps } from '../model/types';
 import { CODE_DEFAULTS } from '../model/constants';
 import { CodeSkeleton } from './CodeSkeleton/CodeSkeleton';
@@ -37,6 +37,7 @@ export const CodeInlineUi = memo(
         className,
         disabled = CODE_DEFAULTS.disabled,
         skeleton = false,
+        asChild = false,
       },
       ref
     ) => {
@@ -57,6 +58,31 @@ export const CodeInlineUi = memo(
         isCopied && styles.copied,
         className
       );
+
+      // asChild: клонируем единственного дочернего ReactElement (Radix Slot pattern),
+      // мержим стили/attrs/обработчики копирования (как Button.asChild)
+      if (asChild) {
+        if (!isValidElement(children)) {
+          return null;
+        }
+        const child = children as React.ReactElement;
+        const childProps = child.props as Record<string, unknown>;
+        const cloned = cloneElement(child, {
+          className: classNames(codeClassName, childProps.className as string | undefined),
+          onClick: copyable && !disabled ? handleClick : undefined,
+          onKeyDown: copyable && !disabled ? onKeyDown : undefined,
+          tabIndex: copyable && !disabled ? 0 : undefined,
+          role: copyable && !disabled ? 'button' : undefined,
+          'aria-label': ariaLabel || (copyable ? 'Click to copy code' : undefined),
+          'data-testid': 'code-inline',
+          'data-size': size,
+          'data-variant': 'inline',
+          'data-skeleton': skeleton || undefined,
+          'aria-busy': skeleton || undefined,
+          ref,
+        } as Record<string, unknown>);
+        return cloned as React.ReactElement;
+      }
 
       return (
         <code

--- a/src/shared/ui/Code/ui/CodeSkeleton/CodeSkeleton.module.scss
+++ b/src/shared/ui/Code/ui/CodeSkeleton/CodeSkeleton.module.scss
@@ -1,0 +1,50 @@
+.blockSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.terminalDots {
+  display: flex;
+  gap: 6px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.red {
+  background-color: #ff5f56;
+}
+
+.yellow {
+  background-color: #ffbd2e;
+}
+
+.green {
+  background-color: #27c93f;
+}
+
+.title {
+  display: flex;
+  flex: 1;
+  gap: 8px;
+  align-items: center;
+}
+
+.language {
+  flex-shrink: 0;
+}
+
+.copyButton {
+  flex-shrink: 0;
+}

--- a/src/shared/ui/Code/ui/CodeSkeleton/CodeSkeleton.tsx
+++ b/src/shared/ui/Code/ui/CodeSkeleton/CodeSkeleton.tsx
@@ -1,0 +1,96 @@
+import { classNames } from '@/shared/lib/utils/classNames';
+import { Skeleton } from '@/shared/ui/Skeleton';
+import type { CodeSize } from '../../model/types';
+import { CODE_DEFAULTS } from '../../model/constants';
+import styles from './CodeSkeleton.module.scss';
+
+export interface CodeSkeletonProps {
+  /** Вариант скелетона: inline — текстовый, block — блок с header + контентом */
+  variant?: 'inline' | 'block';
+  /** Размер (влияет на размеры inline-скелетона) */
+  size?: CodeSize;
+  /** Язык для skeleton-бейджа (только block) */
+  language?: string;
+  /** Заголовок для skeleton (только block) */
+  title?: string;
+  /** Показывать skeleton кнопки копирования (только block) */
+  copyable?: boolean;
+  className?: string;
+}
+
+const INLINE_WIDTH: Record<CodeSize, string> = {
+  sm: '60px',
+  md: '80px',
+  lg: '120px',
+};
+
+const INLINE_HEIGHT: Record<CodeSize, string> = {
+  sm: '1em',
+  md: '1em',
+  lg: '1.5em',
+};
+
+/**
+ * CodeSkeleton — единая точка рендера skeleton-состояний компонента Code.
+ * Заменяет дублирование Skeleton в CodeInlineUi, CodeBlock и CodeBlockHeader (DRY, SR6).
+ */
+export const CodeSkeleton = ({
+  variant = 'inline',
+  size = CODE_DEFAULTS.size,
+  language,
+  title,
+  copyable = false,
+  className,
+}: CodeSkeletonProps) => {
+  if (variant === 'inline') {
+    return (
+      <Skeleton
+        variant="text"
+        width={INLINE_WIDTH[size]}
+        height={INLINE_HEIGHT[size]}
+        className={className}
+        aria-busy="true"
+        data-skeleton="true"
+      />
+    );
+  }
+
+  return (
+    <div
+      className={classNames(styles.blockSkeleton, className)}
+      aria-busy="true"
+      data-skeleton="true"
+    >
+      <div className={styles.header}>
+        <div className={styles.terminalDots}>
+          <div className={classNames(styles.dot, styles.red)} />
+          <div className={classNames(styles.dot, styles.yellow)} />
+          <div className={classNames(styles.dot, styles.green)} />
+        </div>
+        <div className={styles.title}>
+          {language && (
+            <Skeleton variant="text" width="36px" height="0.75rem" className={styles.language} />
+          )}
+          {title && <Skeleton variant="text" width="120px" height="0.875rem" />}
+        </div>
+        {copyable && (
+          <Skeleton
+            variant="rectangular"
+            width="64px"
+            height="28px"
+            className={styles.copyButton}
+          />
+        )}
+      </div>
+      <Skeleton
+        variant="rectangular"
+        width="100%"
+        height="310px"
+        aria-busy="true"
+        data-skeleton="true"
+      />
+    </div>
+  );
+};
+
+CodeSkeleton.displayName = 'CodeSkeleton';


### PR DESCRIPTION
## Release: shared/ui/Code → Senior+ (SR1–SR8)

Ветка `dev` содержит полный цикл улучшения компонента Code (issue #29):

- P1 (PR #30): forwardRef (SR1), public API cleanup (SR2), убрать default export (SR3)
- P2 (PR #31): Toast decoupling onCopyResult (SR4), единый CodeSkeleton (SR6)
- P3 (PR #32): asChild inline (SR7), copyTimeout (SR8)
- Review fixes (PR #33): i18n Hero copy (HARD, CONTRIBUTING.md:45), композиция asChild handlers/ref через mergeRefs (SR7)

Двухосевой кодревью (Standards + Spec) — PASS. `npm run validate` зелёный: 2247 тестов, type-check + lint + stylelint.

Релиз `dev → main` (Ruleset 21331400: 6 required status checks — Strict Validation, Security Audit, Secret Scan/gitleaks, CodeQL, Bundle Size Check, Conventional Commits).