### PR TITLE
release: shared/ui/AnimatedSection Senior+ (SR1-SR6) -> main

### DIFF
--- a/src/shared/lib/hooks/useScrollAnimation.ts
+++ b/src/shared/lib/hooks/useScrollAnimation.ts
@@ -194,5 +194,3 @@ export const useScrollAnimation = ({
     resetAnimation,
   };
 };
-
-export default useScrollAnimation;

--- a/src/shared/ui/AnimatedSection/model/types.ts
+++ b/src/shared/ui/AnimatedSection/model/types.ts
@@ -2,7 +2,7 @@
 // AnimatedSection Component - TypeScript Types
 // ============================================
 
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef, type ElementType } from 'react';
 
 /**
  * Animation types
@@ -78,5 +78,11 @@ export interface AnimatedSectionProps extends ComponentPropsWithoutRef<'div'> {
    * HTML element type
    * @default 'div'
    */
-  as?: keyof React.JSX.IntrinsicElements;
+  as?: ElementType;
+
+  /**
+   * Stagger delay between direct children (ms)
+   * @default 0
+   */
+  stagger?: number;
 }

--- a/src/shared/ui/AnimatedSection/ui/AnimatedSection.module.scss
+++ b/src/shared/ui/AnimatedSection/ui/AnimatedSection.module.scss
@@ -14,6 +14,7 @@ $animation-offset-lg: 100px;
     opacity var(--animation-duration, 700ms) ease,
     transform var(--animation-duration, 700ms) ease;
   transition-delay: var(--animation-delay, 0ms);
+  will-change: opacity, transform;
 
   // Animation types
   &.fadeIn {
@@ -56,6 +57,24 @@ $animation-offset-lg: 100px;
     opacity: 1;
     transform: none;
     transition: none;
+  }
+
+  // Stagger children (SR1)
+  .staggerChild {
+    opacity: 0;
+    transform: translateY($animation-offset-sm);
+    transition:
+      opacity var(--animation-duration, 700ms) ease,
+      transform var(--animation-duration, 700ms) ease;
+  }
+
+  &.visible .staggerChild {
+    opacity: 1;
+    transform: none;
+  }
+
+  &.animating .staggerChild {
+    transition-delay: 0ms;
   }
 
   // Accessibility: Reduced Motion

--- a/src/shared/ui/AnimatedSection/ui/AnimatedSection.test.tsx
+++ b/src/shared/ui/AnimatedSection/ui/AnimatedSection.test.tsx
@@ -3,7 +3,8 @@
 // ============================================
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { type ReactNode } from 'react';
 import { AnimatedSection } from './AnimatedSection';
 import styles from './AnimatedSection.module.scss';
 
@@ -296,6 +297,67 @@ describe('AnimatedSection', () => {
 
       const element = container.firstChild as HTMLElement;
       expect(element).toBeInTheDocument();
+    });
+  });
+
+  // ============================================
+  // SR4: Accessibility (aria-hidden during motion)
+  // ============================================
+  describe('a11y aria-hidden (SR4)', () => {
+    it('sets aria-hidden during animation and removes it after', () => {
+      const { container } = render(
+        <AnimatedSection trigger="manual" animate={true}>
+          Content
+        </AnimatedSection>
+      );
+      const element = container.firstChild as HTMLElement;
+      expect(element).toHaveAttribute('aria-hidden', 'true');
+
+      act(() => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(element).not.toHaveAttribute('aria-hidden');
+    });
+  });
+
+  // ============================================
+  // SR2: polymorphic as prop accepts custom components (ElementType)
+  // ============================================
+  describe('polymorphic as prop (SR2)', () => {
+    it('renders a custom component via as prop', () => {
+      const Custom = ({ children }: { children?: ReactNode }) => <article>{children}</article>;
+      const { container } = render(<AnimatedSection as={Custom}>Content</AnimatedSection>);
+      expect((container.firstChild as HTMLElement).tagName).toBe('ARTICLE');
+    });
+  });
+
+  // ============================================
+  // SR1: stagger
+  // ============================================
+  describe('stagger (SR1)', () => {
+    it('applies incremental transition-delay to direct children', () => {
+      render(
+        <AnimatedSection stagger={100}>
+          <div data-testid="c1">A</div>
+          <div data-testid="c2">B</div>
+        </AnimatedSection>
+      );
+      expect(screen.getByTestId('c1').style.transitionDelay).toBe('0ms');
+      expect(screen.getByTestId('c2').style.transitionDelay).toBe('100ms');
+    });
+  });
+
+  // ============================================
+  // SR5: reduced-motion (CSS-only) smoke test
+  // ============================================
+  describe('reduced-motion (SR5)', () => {
+    it('renders children without crashing (a11y handled via CSS media query)', () => {
+      render(
+        <AnimatedSection>
+          <span data-testid="rm">Reduced</span>
+        </AnimatedSection>
+      );
+      expect(screen.getByTestId('rm')).toBeInTheDocument();
     });
   });
 });

--- a/src/shared/ui/AnimatedSection/ui/AnimatedSection.tsx
+++ b/src/shared/ui/AnimatedSection/ui/AnimatedSection.tsx
@@ -2,7 +2,16 @@
 // AnimatedSection Component
 // ============================================
 
-import { forwardRef, memo, useEffect, type CSSProperties, type ElementType } from 'react';
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  memo,
+  useEffect,
+  type CSSProperties,
+  type ReactElement,
+} from 'react';
 import { useScrollAnimation } from '@/shared/lib/hooks/useScrollAnimation';
 import { classNames } from '@/shared/lib/utils/classNames';
 import { useMergeRefs } from '@/shared/lib/utils/mergeRefs';
@@ -59,6 +68,7 @@ export const AnimatedSection = memo(
         onAnimationStart,
         onAnimationComplete,
         as: Component = 'div',
+        stagger = 0,
         ...props
       },
       ref
@@ -114,7 +124,25 @@ export const AnimatedSection = memo(
       // Build data-state for accessibility and testing
       const dataState = isVisible ? 'visible' : hasAnimated ? 'animated' : 'hidden';
 
-      const ComponentElement = Component as ElementType;
+      const ComponentElement = Component;
+
+      const renderedChildren =
+        stagger > 0
+          ? Children.map(children, (child, index) => {
+              if (!isValidElement(child)) return child;
+              const childProps = child.props as { className?: string; style?: CSSProperties };
+              return cloneElement(
+                child as ReactElement<{ className?: string; style?: CSSProperties }>,
+                {
+                  className: classNames(styles.staggerChild, childProps.className),
+                  style: {
+                    ...childProps.style,
+                    transitionDelay: `${delay + index * stagger}ms`,
+                  },
+                }
+              );
+            })
+          : children;
 
       return (
         <ComponentElement
@@ -122,11 +150,12 @@ export const AnimatedSection = memo(
           className={animationClasses}
           style={inlineStyles}
           onMouseEnter={trigger === 'onHover' ? triggerAnimation : undefined}
+          aria-hidden={isAnimating || undefined}
           data-testid="animated-section"
           data-state={dataState}
           {...props}
         >
-          {children}
+          {renderedChildren}
         </ComponentElement>
       );
     }


### PR DESCRIPTION
Reconciliation of wiki/ui-kit-improvement-animatedsection.md against actual code (verified 2026-08-26). All 6 SR items implemented and merged to dev via #42.

## Changes (from #42)
- SR6: drop dead `export default` from `useScrollAnimation`
- SR2: widen `as` prop type -> `React.ElementType`
- SR3: `will-change: opacity, transform` on `.animatedSection`
- SR4: `aria-hidden={isAnimating}` during motion
- SR1: `stagger?: number` prop (sequential child delays)
- SR5: reduced-motion stays CSS-only; added smoke/a11y test

`npm run validate` green; 27 AnimatedSection tests + hook tests green.

Closes #41