### PR TITLE
Slot: Senior+ improvements (SR1/SR3/SR4)

### DIFF
--- a/src/shared/ui/Slot/model/types.ts
+++ b/src/shared/ui/Slot/model/types.ts
@@ -1,23 +1,13 @@
-import type { ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
-export interface SlotProps {
+export interface SlotProps extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   /**
    * Единственный дочерний ReactElement
    */
   children: ReactNode;
 
   /**
-   * Дополнительные CSS классы (мержатся с классами children)
-   */
-  className?: string;
-
-  /**
-   * ID элемента
-   */
-  id?: string;
-
-  /**
-   * Data-testid для тестирования
+   * Data-testid для тестирования (переопределяет дочерний)
    */
   'data-testid'?: string;
 

--- a/src/shared/ui/Slot/ui/Slot.stories.tsx
+++ b/src/shared/ui/Slot/ui/Slot.stories.tsx
@@ -1,25 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 import { Slot } from './Slot';
 
 /**
- * ## Slot Component
- *
  * Slot не создаёт свой DOM-узел, а клонирует единственного дочернего ReactElement
  * с merged className, id, data-testid и ref.
- *
- * ### Особенности:
- * - Прозрачный рендеринг — не добавляет обёрток в DOM
- * - Merged className (родительский + дочерний)
- * - Проброс id, data-testid, ref
- * - Children.only — принимает ровно один ReactElement
- *
- * ### Использование:
- * ```tsx
- * <Slot className="wrapper">
- *   <span>Оригинальный элемент</span>
- * </Slot>
- * // → <span class="wrapper">Оригинальный элемент</span>
- * ```
  */
 const meta: Meta<typeof Slot> = {
   title: 'shared/Slot',
@@ -48,6 +33,12 @@ export const Default: Story = {
       <span>Текст внутри span через Slot</span>
     </Slot>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-default');
+    await expect(el.tagName).toBe('SPAN');
+    await expect(el).toHaveTextContent('Текст внутри span через Slot');
+  },
 };
 
 /**
@@ -69,6 +60,12 @@ export const WithClassName: Story = {
       </Slot>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-class');
+    await expect(el).toHaveClass('parent-class');
+    await expect(el).toHaveClass('child-class');
+  },
 };
 
 /**
@@ -80,6 +77,11 @@ export const WithId: Story = {
       <span>Элемент с id="slot-id-example"</span>
     </Slot>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-id');
+    await expect(el).toHaveAttribute('id', 'slot-id-example');
+  },
 };
 
 /**
@@ -93,6 +95,11 @@ export const WithDataTestId: Story = {
       </span>
     </Slot>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('overridden-testid');
+    await expect(el).toHaveTextContent('Оригинальный data-testid переопределён');
+  },
 };
 
 /**
@@ -114,6 +121,12 @@ export const WithButton: Story = {
       </button>
     </Slot>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-button');
+    await expect(el.tagName).toBe('BUTTON');
+    await expect(el).toHaveClass('slot-button');
+  },
 };
 
 /**
@@ -139,6 +152,12 @@ export const WithDiv: Story = {
       </Slot>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-div');
+    await expect(el.tagName).toBe('DIV');
+    await expect(el).toHaveClass('slot-div');
+  },
 };
 
 /**
@@ -154,4 +173,10 @@ export const WithLabel: Story = {
       </Slot>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByTestId('slot-label');
+    await expect(el.tagName).toBe('LABEL');
+    await expect(el).toHaveClass('slot-label');
+  },
 };

--- a/src/shared/ui/Slot/ui/Slot.test.tsx
+++ b/src/shared/ui/Slot/ui/Slot.test.tsx
@@ -114,5 +114,41 @@ describe('Slot', () => {
       expect(refCallback).toHaveBeenCalled();
       expect(refCallback.mock.calls[0]?.[0]).toBeInstanceOf(HTMLSpanElement);
     });
+
+    it('должен пробросить dataAttrs в потомка', () => {
+      render(
+        <Slot dataAttrs={{ 'data-size': 'xl', 'data-theme': 'dark' }} data-testid="slot">
+          <span>Child</span>
+        </Slot>
+      );
+
+      const element = screen.getByTestId('slot');
+      expect(element).toHaveAttribute('data-size', 'xl');
+      expect(element).toHaveAttribute('data-theme', 'dark');
+    });
+
+    it('должен пробросить rest-пропсы (aria-*, role) в потомка', () => {
+      render(
+        <Slot role="navigation" aria-label="slot-region" data-testid="slot">
+          <nav>Child</nav>
+        </Slot>
+      );
+
+      const element = screen.getByTestId('slot');
+      expect(element).toHaveAttribute('role', 'navigation');
+      expect(element).toHaveAttribute('aria-label', 'slot-region');
+    });
+
+    it('rest-пропсы не конфликтуют с dataAttrs', () => {
+      render(
+        <Slot dataAttrs={{ 'data-size': 'xl' }} role="main" data-testid="slot">
+          <div>Child</div>
+        </Slot>
+      );
+
+      const element = screen.getByTestId('slot');
+      expect(element).toHaveAttribute('data-size', 'xl');
+      expect(element).toHaveAttribute('role', 'main');
+    });
   });
 });

--- a/src/shared/ui/Slot/ui/Slot.tsx
+++ b/src/shared/ui/Slot/ui/Slot.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement, forwardRef, isValidElement } from 'react';
+import { Children, cloneElement, forwardRef, isValidElement, memo } from 'react';
 import type { SlotProps } from '../model/types';
 
 /**
@@ -13,48 +13,50 @@ import type { SlotProps } from '../model/types';
  * // → <span class="original-class wrapper-class" data-testid="slot">Оригинальный элемент</span>
  * ```
  */
-export const Slot = forwardRef<HTMLElement, SlotProps>((props, ref) => {
-  const { children, className, id, 'data-testid': dataTestId, dataAttrs } = props;
+export const Slot = memo(
+  forwardRef<HTMLElement, SlotProps>((props, ref) => {
+    const { children, className, id, 'data-testid': dataTestId, dataAttrs, ...rest } = props;
 
-  const child = Children.only(children);
+    const child = Children.only(children);
 
-  if (!isValidElement(child)) {
-    return null;
-  }
+    if (!isValidElement(child)) {
+      return null;
+    }
 
-  const childProps = child.props as Record<string, unknown>;
-  const mergedProps: Record<string, unknown> = {};
+    const childProps = child.props as Record<string, unknown>;
+    const mergedProps: Record<string, unknown> = { ...rest };
 
-  // Merged className: child's original + parent's (parent wins on conflicts via order)
-  if (className) {
-    const existingClassName = childProps.className;
-    mergedProps.className = existingClassName
-      ? `${className} ${String(existingClassName)}`
-      : className;
-  }
+    // Merged className: child's original + parent's (parent wins on conflicts via order)
+    if (className) {
+      const existingClassName = childProps.className;
+      mergedProps.className = existingClassName
+        ? `${className} ${String(existingClassName)}`
+        : className;
+    }
 
-  // id and data-testid override child's values
-  if (id) {
-    mergedProps.id = id;
-  }
+    // id and data-testid override child's values
+    if (id) {
+      mergedProps.id = id;
+    }
 
-  if (dataTestId) {
-    mergedProps['data-testid'] = dataTestId;
-  }
+    if (dataTestId) {
+      mergedProps['data-testid'] = dataTestId;
+    }
 
-  // Forward arbitrary data-attributes (data-size, data-theme, data-as, etc.)
-  if (dataAttrs) {
-    Object.keys(dataAttrs).forEach((key) => {
-      mergedProps[key] = dataAttrs[key];
-    });
-  }
+    // Forward arbitrary data-attributes (data-size, data-theme, data-as, etc.)
+    if (dataAttrs) {
+      Object.keys(dataAttrs).forEach((key) => {
+        mergedProps[key] = dataAttrs[key];
+      });
+    }
 
-  // Forward ref to child
-  if (ref) {
-    mergedProps.ref = ref;
-  }
+    // Forward ref to child
+    if (ref) {
+      mergedProps.ref = ref;
+    }
 
-  return cloneElement(child, mergedProps);
-});
+    return cloneElement(child, mergedProps);
+  })
+);
 
 Slot.displayName = 'Slot';


### PR DESCRIPTION
Closes #46

Senior+ доработка \`shared/ui/Slot\` (см. issue #46 и вики ui-kit-improvement-slot.md):

- **SR1**: play-функции во все 7 stories (было 0/7)
- **SR3**: обёртка Slot в React.memo
- **SR4**: ...rest проброс (aria-*, role, style) рядом с dataAttrs

Не делаем SR2 (classNames неприменим — reverse-merge parent→child).

Потребители не ломаются: Paragraph, Label.
Проверка: validate + test:storybook зелёные (649/0).