### PR TITLE
fix(Button): resolve 4R code-review findings (major + minor)

### DIFF
--- a/src/shared/ui/Button/lib/hooks/useButton.test.tsx
+++ b/src/shared/ui/Button/lib/hooks/useButton.test.tsx
@@ -63,10 +63,11 @@ describe('useButton', () => {
       expect(result.current.contentClassName).toContain('content');
     });
 
-    it('должен добавлять hidden класс при loading=true', () => {
+    it('не должен добавлять hidden класс при loading=true (dead class removed)', () => {
       const { result } = renderHook(() => useButton(createDefaultOptions({ loading: true })));
 
-      expect(result.current.contentClassName).toContain('hidden');
+      expect(result.current.contentClassName).toContain('content');
+      expect(result.current.contentClassName).not.toContain('hidden');
     });
 
     it('не должен добавлять hidden класс при loading=false', () => {

--- a/src/shared/ui/Button/lib/hooks/useButton.tsx
+++ b/src/shared/ui/Button/lib/hooks/useButton.tsx
@@ -34,7 +34,7 @@ export interface UseButtonOptions {
    * @description When provided, the hook uses these styles instead of the default Button styles.
    * Allows IconButton and ButtonWithIcon to reuse the hook with their own CSS modules.
    */
-  styles?: Record<string, string>;
+  moduleStyles?: Record<string, string>;
 }
 
 /**
@@ -47,6 +47,8 @@ export interface UseButtonReturn {
   contentClassName: string;
   /** Guarded click handler that prevents interaction when disabled or loading */
   handleClick: React.MouseEventHandler;
+  /** Keyboard handler that triggers click on Enter/Space for non-native elements */
+  handleKeyDown: React.KeyboardEventHandler;
   /** Loader element (Spinner/Skeleton) or null when not loading */
   loader: ReactNode | null;
 }
@@ -55,11 +57,12 @@ export interface UseButtonReturn {
  * Shared hook that consolidates Button logic duplicated across Button, ButtonWithIcon, and IconButton.
  *
  * @remarks
- * Handles className computation, guarded click handling, runtime validation, and loader rendering.
- * All three button components use this hook internally.
+ * Handles className computation (including the `danger -> primary + danger color-scheme`
+ * resolution), guarded click/keyboard handling, runtime validation (incl. colorScheme),
+ * and loader rendering. All three button components use this hook internally.
  *
  * @param options - Configuration matching the common button props
- * @returns Computed class names, event handler, and loader element
+ * @returns Computed class names, event handlers, and loader element
  */
 export const useButton = ({
   variant,
@@ -71,38 +74,44 @@ export const useButton = ({
   disabled,
   className,
   onClick,
-  styles: customStyles,
+  moduleStyles: customStyles,
 }: UseButtonOptions): UseButtonReturn => {
   // Use custom styles (for IconButton/ButtonWithIcon) or default to Button styles
   const s = customStyles ?? buttonStyles;
-  // Runtime validation in development mode
+
+  // Runtime validation in development mode (includes colorScheme validation)
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
-      const warnings = validateButtonProps(variant, size, loadingVariant, loading);
+      const warnings = validateButtonProps(variant, size, loadingVariant, loading, colorScheme);
       warnings.forEach((w) => {
         // eslint-disable-next-line no-console
         console.warn(w.message);
       });
     }
-  }, [variant, size, loadingVariant, loading]);
+  }, [variant, size, loadingVariant, loading, colorScheme]);
+
+  // Resolve the `danger` variant to its visual + semantic representation once, here,
+  // so the three components don't each duplicate the mapping.
+  const effectiveVariant: ButtonVariant = variant === 'danger' ? 'primary' : variant;
+  const effectiveScheme = colorScheme ?? (variant === 'danger' ? 'danger' : undefined);
 
   // Memoize className calculation
   const buttonClassName = useMemo(
     () =>
       classNames(
         s.button,
-        s[variant],
+        s[effectiveVariant],
         s[size],
-        colorScheme && s[`color-scheme-${colorScheme}`],
+        effectiveScheme && s[`color-scheme-${effectiveScheme}`],
         loading && s.loading,
         fullWidth && s.fullWidth,
         className
       ),
-    [variant, size, colorScheme, loading, fullWidth, className, s]
+    [effectiveVariant, effectiveScheme, size, loading, fullWidth, className, s]
   );
 
   // Memoize content className
-  const contentClassName = useMemo(() => classNames(s.content, loading && s.hidden), [loading, s]);
+  const contentClassName = useMemo(() => classNames(s.content), [s]);
 
   // Memoize guarded click handler
   const handleClick = useCallback(
@@ -112,6 +121,20 @@ export const useButton = ({
         return;
       }
       onClick?.(event);
+    },
+    [disabled, loading, onClick]
+  );
+
+  // Keyboard activation for non-native interactive elements (div/span with role="button")
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent): void => {
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+        if (disabled || loading) {
+          event.preventDefault();
+          return;
+        }
+        onClick?.(event as unknown as React.MouseEvent);
+      }
     },
     [disabled, loading, onClick]
   );
@@ -129,6 +152,7 @@ export const useButton = ({
     buttonClassName,
     contentClassName,
     handleClick,
+    handleKeyDown,
     loader,
   };
 };

--- a/src/shared/ui/Button/lib/utils/mergeRefs.ts
+++ b/src/shared/ui/Button/lib/utils/mergeRefs.ts
@@ -1,0 +1,29 @@
+// ============================================
+// mergeRefs — combine multiple refs into one callback ref
+// ============================================
+
+import type { MutableRefObject, Ref, RefCallback } from 'react';
+
+/**
+ * Merges multiple refs (callback or object) into a single callback ref.
+ *
+ * @param refs - Refs to combine (undefined entries are ignored)
+ * @returns A callback ref that assigns the value to every provided ref
+ *
+ * @example
+ * ```ts
+ * const merged = mergeRefs(externalRef, internalRef);
+ * <div ref={merged} />
+ * ```
+ */
+export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
+  return (value: T | null) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        (ref as RefCallback<T>)(value);
+      } else if (ref != null) {
+        (ref as MutableRefObject<T | null>).current = value;
+      }
+    }
+  };
+}

--- a/src/shared/ui/Button/lib/utils/safeHref.ts
+++ b/src/shared/ui/Button/lib/utils/safeHref.ts
@@ -1,0 +1,48 @@
+// ============================================
+// safeHref — block dangerous URL schemes for polymorphic <a>
+// ============================================
+
+const SAFE_PROTOCOLS = ['http:', 'https:', 'mailto:', 'tel:'];
+
+/**
+ * Validates an `href` value against dangerous URL schemes (e.g. `javascript:`, `data:`).
+ *
+ * @description Allows http(s)/mailto/tel, plus relative/root-relative/hash/query paths.
+ * Returns `undefined` for unsafe schemes (and warns in development), so the link is
+ * effectively neutralised instead of executing injected script.
+ *
+ * @param href - The raw href attribute
+ * @returns The safe href, or undefined when the scheme is disallowed
+ *
+ * @example
+ * sanitizeHref('https://example.com')   // => 'https://example.com'
+ * sanitizeHref('/about')                // => '/about'
+ * sanitizeHref('javascript:alert(1)')   // => undefined (blocked)
+ */
+export function sanitizeHref(href: string): string | undefined {
+  if (typeof href !== 'string') return undefined;
+  const trimmed = href.trim();
+  if (trimmed === '') return undefined;
+
+  // Relative / root-relative / hash / query paths are always safe
+  if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('?')) {
+    return trimmed;
+  }
+
+  try {
+    const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const url = new URL(trimmed, base);
+    if (SAFE_PROTOCOLS.includes(url.protocol)) {
+      return trimmed;
+    }
+  } catch {
+    // Not an absolute URL (relative without base) — treat as safe path
+    return trimmed;
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(`[Button] Blocked potentially unsafe href scheme: "${trimmed}"`);
+  }
+  return undefined;
+}

--- a/src/shared/ui/Button/lib/utils/sanitizeAnchorProps.ts
+++ b/src/shared/ui/Button/lib/utils/sanitizeAnchorProps.ts
@@ -1,0 +1,34 @@
+// ============================================
+// sanitizeAnchorProps — harden polymorphic <a> rendering
+// ============================================
+
+import { sanitizeHref } from './safeHref';
+
+/**
+ * Sanitizes anchor props for the polymorphic `component="a"` case.
+ *
+ * @description
+ * - Blocks dangerous `href` schemes via {@link sanitizeHref}.
+ * - Auto-adds `rel="noopener noreferrer"` for `target="_blank"` when not explicitly set.
+ *
+ * @param props - The rest props spread for the rendered `<a>` element
+ * @returns A new props object with sanitized href and hardened rel
+ */
+export function sanitizeAnchorProps(props: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...props };
+
+  if (typeof props.href === 'string') {
+    const safe = sanitizeHref(props.href);
+    if (safe === undefined) {
+      delete next.href;
+    } else {
+      next.href = safe;
+    }
+  }
+
+  if (props.target === '_blank' && !('rel' in props)) {
+    next.rel = 'noopener noreferrer';
+  }
+
+  return next;
+}

--- a/src/shared/ui/Button/model/constants.ts
+++ b/src/shared/ui/Button/model/constants.ts
@@ -26,6 +26,8 @@ export const BUTTON_CONSTANTS = {
   ] as const satisfies readonly ButtonColorScheme[],
   VALID_LOADING_VARIANTS: ['spinner', 'skeleton'] as const satisfies readonly LoadingVariant[],
   DEFAULT_SPINNER_LABEL: 'Loading',
+  LOADER_SPINNER_SIZE: 'sm',
+  LOADER_SPINNER_COLOR: 'secondary',
 } as const;
 
 /**

--- a/src/shared/ui/Button/model/types.ts
+++ b/src/shared/ui/Button/model/types.ts
@@ -31,70 +31,6 @@ export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type LoadingVariant = 'spinner' | 'skeleton';
 
 // ============================================
-// Base props для всех кнопок
-// ============================================
-
-/**
- * Базовые props для всех типов кнопок
- * @description Содержит только props, используемые компонентами Button.
- * Без extends ButtonHTMLAttributes — type и другие button-атрибуты
- * проксируются через PolymorphicProps при component="button".
- * @group Base
- */
-interface BaseButtonProps {
-  /**
-   * Визуальный стиль кнопки
-   * @default 'primary'
-   */
-  variant?: ButtonVariant;
-
-  /**
-   * Размер кнопки
-   * @default 'md'
-   */
-  size?: ButtonSize;
-
-  /**
-   * HTML type атрибут
-   * @default 'button'
-   * @description Проксируется только при component="button"
-   */
-  type?: 'button' | 'submit' | 'reset';
-
-  /**
-   * Отключенное состояние
-   * @default false
-   * @description Блокирует взаимодействие и добавляет aria-disabled
-   */
-  disabled?: boolean;
-
-  /**
-   * Состояние загрузки
-   * @default false
-   * @description Скрывает контент и показывает loader
-   */
-  loading?: boolean;
-
-  /**
-   * Тип индикатора загрузки
-   * @default 'spinner'
-   * @description Выбирает между spinner и skeleton
-   */
-  loadingVariant?: LoadingVariant;
-
-  /**
-   * Растянуть на всю ширину контейнера
-   * @default false
-   */
-  fullWidth?: boolean;
-
-  /**
-   * Дополнительный CSS класс
-   */
-  className?: string;
-}
-
-// ============================================
 // Button — только текст
 // ============================================
 
@@ -111,30 +47,12 @@ interface BaseButtonProps {
  * @example
  * <Button loading>Loading...</Button>
  */
-export interface ButtonProps extends BaseButtonProps {
+export interface ButtonProps extends ButtonOwnProps {
   /**
    * Текстовый контент кнопки
    * @required
    */
   children: ReactNode;
-
-  /**
-   * Не используется для Button
-   * @internal
-   */
-  leftIcon?: undefined;
-
-  /**
-   * Не используется для Button
-   * @internal
-   */
-  rightIcon?: undefined;
-
-  /**
-   * Не используется для Button
-   * @internal
-   */
-  ariaLabel?: undefined;
 }
 
 // ============================================
@@ -162,7 +80,7 @@ export interface ButtonProps extends BaseButtonProps {
  *   size="lg"
  * />
  */
-export interface IconButtonProps extends BaseButtonProps {
+export interface IconButtonProps extends ButtonOwnProps {
   /**
    * React компонент иконки (обычно из lucide-react)
    * @required
@@ -176,24 +94,6 @@ export interface IconButtonProps extends BaseButtonProps {
    * @description Обязательно для accessibility
    */
   ariaLabel: string;
-
-  /**
-   * Не используется для IconButton
-   * @internal
-   */
-  children?: undefined;
-
-  /**
-   * Не используется для IconButton
-   * @internal
-   */
-  leftIcon?: undefined;
-
-  /**
-   * Не используется для IconButton
-   * @internal
-   */
-  rightIcon?: undefined;
 }
 
 // ============================================
@@ -221,7 +121,7 @@ export interface IconButtonProps extends BaseButtonProps {
  *   Навигация
  * </ButtonWithIcon>
  */
-export interface ButtonWithIconProps extends BaseButtonProps {
+export interface ButtonWithIconProps extends ButtonOwnProps {
   /**
    * Текстовый контент кнопки
    * @required
@@ -241,18 +141,6 @@ export interface ButtonWithIconProps extends BaseButtonProps {
    * @example <ArrowRight size={18} />
    */
   rightIcon?: ReactNode;
-
-  /**
-   * Не используется для ButtonWithIcon
-   * @internal
-   */
-  icon?: undefined;
-
-  /**
-   * Не используется для ButtonWithIcon
-   * @internal
-   */
-  ariaLabel?: undefined;
 }
 
 // ============================================
@@ -293,8 +181,13 @@ export interface ButtonOwnProps {
   className?: string;
   onClick?: React.MouseEventHandler;
   /**
+   * HTML type атрибут (только для component="button")
+   * @default 'button'
+   */
+  type?: 'button' | 'submit' | 'reset';
+  /**
    * Render the button as a child element instead of creating its own DOM node.
-   * @description When true, the button clones its single child and merges all
+   * @description When true, the button clones its single child (or `icon`) and merges all
    * button props (styles, events, aria attributes) into it. Useful for composition
    * with `<a>`, `<Link>`, or other custom components.
    *

--- a/src/shared/ui/Button/ui/Button/Button.module.scss
+++ b/src/shared/ui/Button/ui/Button/Button.module.scss
@@ -43,10 +43,6 @@
     @include variant-sidebar;
   }
 
-  &.danger {
-    @include variant-danger;
-  }
-
   // Color schemes
   @include color-schemes;
 
@@ -93,6 +89,12 @@
 
   &.loading {
     @include button-loading;
+  }
+
+  &.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   // ============================================

--- a/src/shared/ui/Button/ui/Button/Button.test.tsx
+++ b/src/shared/ui/Button/ui/Button/Button.test.tsx
@@ -79,10 +79,11 @@ describe('Button', () => {
       expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('должен быть disabled при loading=true', () => {
+    it('должен иметь aria-busy и aria-disabled при loading=true (не нативно disabled)', () => {
       render(<Button loading>Loading</Button>);
 
-      expect(screen.getByRole('button')).toBeDisabled();
+      expect(screen.getByRole('button')).not.toBeDisabled();
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
       expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
     });
 
@@ -120,11 +121,13 @@ describe('Button', () => {
       expect(screen.getByRole('button')).toHaveClass(buttonStyles.loading ?? '');
     });
 
-    it('должен скрывать контент при loading=true', () => {
+    it('должен скрывать контент при loading=true (через CSS loading-класс)', () => {
       render(<Button loading>Loading</Button>);
 
-      const content = screen.getByRole('button').querySelector(`.${buttonStyles.content ?? ''}`);
-      expect(content).toHaveClass(buttonStyles.hidden ?? '');
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass(buttonStyles.loading ?? '');
+      const content = button.querySelector(`.${buttonStyles.content ?? ''}`);
+      expect(content).toBeInTheDocument();
     });
   });
 
@@ -247,6 +250,31 @@ describe('Button', () => {
       const link = screen.getByTestId('button');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener');
+    });
+
+    it('должен блокировать javascript: href (XSS)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      render(
+        // eslint-disable-next-line no-script-url -- intent: assert this dangerous URL is blocked
+        <Button component="a" href="javascript:alert(1)">
+          Link
+        </Button>
+      );
+
+      const link = screen.getByTestId('button');
+      expect(link).not.toHaveAttribute('href');
+      warn.mockRestore();
+    });
+
+    it('должен добавлять rel="noopener noreferrer" для target="_blank" без rel', () => {
+      render(
+        <Button component="a" href="/about" target="_blank">
+          Link
+        </Button>
+      );
+
+      const link = screen.getByTestId('button');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('не должен иметь disabled атрибута при component="a"', () => {

--- a/src/shared/ui/Button/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/ui/Button/Button.tsx
@@ -6,6 +6,8 @@ import { classNames } from '@/shared/lib/utils/classNames';
 import React, { Children, cloneElement, isValidElement } from 'react';
 import type { ButtonOwnProps, PolymorphicProps } from '../../model/types';
 import { useButton } from '../../lib/hooks/useButton';
+import { mergeRefs } from '../../lib/utils/mergeRefs';
+import { sanitizeAnchorProps } from '../../lib/utils/sanitizeAnchorProps';
 import styles from './Button.module.scss';
 
 /**
@@ -31,7 +33,7 @@ import styles from './Button.module.scss';
  * <Button component="a" href="/about">Link</Button>
  * ```
  */
-function ButtonImpl<C extends React.ElementType = 'button'>(
+function ButtonImpl(
   {
     children,
     variant = 'primary',
@@ -47,13 +49,13 @@ function ButtonImpl<C extends React.ElementType = 'button'>(
     component,
     asChild = false,
     ...props
-  }: PolymorphicProps<C, ButtonOwnProps>,
-  ref: React.ForwardedRef<React.ComponentRef<C>>
+  }: PolymorphicProps<React.ElementType, ButtonOwnProps>,
+  ref: React.ForwardedRef<React.ComponentRef<React.ElementType>>
 ) {
-  const { buttonClassName, contentClassName, handleClick, loader } = useButton({
-    variant: variant === 'danger' ? 'primary' : variant,
+  const { buttonClassName, contentClassName, handleClick, handleKeyDown, loader } = useButton({
+    variant,
     size,
-    colorScheme: colorScheme ?? (variant === 'danger' ? 'danger' : undefined),
+    colorScheme,
     loading,
     loadingVariant,
     fullWidth,
@@ -62,50 +64,64 @@ function ButtonImpl<C extends React.ElementType = 'button'>(
     onClick,
   });
 
-  // asChild mode: merge props into child element instead of rendering own DOM node
+  const isDisabled = disabled || loading;
+  const Tag = component || ('button' as React.ElementType);
+  const isButtonElement = Tag === 'button';
+  const isNativeInteractive = isButtonElement || Tag === 'a';
+
+  // asChild mode: merge button props into a single child element instead of rendering own DOM node
   if (asChild) {
-    const child = Children.only(children);
-    if (!isValidElement(child)) {
-      return null;
-    }
-
-    const isDisabled = disabled || loading;
-    const childProps = child.props as Record<string, unknown>;
-
     /* eslint-disable react-hooks/refs */
-    return cloneElement(child, {
-      className: classNames(
-        buttonClassName,
-        childProps.className as string,
-        isDisabled && styles.disabled
-      ),
-      onClick: handleClick,
-      'aria-disabled': isDisabled || undefined,
-      'aria-busy': loading || undefined,
-      'data-state': loading ? 'loading' : 'idle',
-      'data-testid': 'button',
-      ref: ref as React.Ref<unknown>,
-      ...props,
-    } as Record<string, unknown>) as React.ReactElement;
+    const childArray = Children.toArray(children);
+    if (childArray.length === 1 && isValidElement(childArray[0])) {
+      const child = childArray[0];
+      const childProps = child.props as Record<string, unknown>;
+      const childOnClick = childProps.onClick as React.MouseEventHandler | undefined;
+      const childRef = childProps.ref as React.Ref<unknown> | undefined;
+
+      const mergedOnClick: React.MouseEventHandler = (event) => {
+        childOnClick?.(event);
+        handleClick(event);
+      };
+      const mergedRef = mergeRefs(ref as React.Ref<unknown>, childRef);
+
+      return cloneElement(child, {
+        className: classNames(
+          buttonClassName,
+          childProps.className as string,
+          isDisabled && styles.disabled
+        ),
+        onClick: mergedOnClick,
+        ref: mergedRef,
+        'aria-disabled': isDisabled || undefined,
+        'aria-busy': loading || undefined,
+        'data-state': loading ? 'loading' : 'idle',
+        'data-testid': 'button',
+        ...props,
+      } as Record<string, unknown>) as React.ReactElement;
+    }
+    // Fall through to normal render when asChild child is invalid
     /* eslint-enable react-hooks/refs */
   }
 
-  const Tag = component || ('button' as React.ElementType);
-  const isButtonElement = Tag === 'button';
-  const isDisabled = disabled || loading;
+  // Harden anchor rendering: sanitize href scheme + rel="noopener noreferrer" for _blank
+  const safeProps = Tag === 'a' ? sanitizeAnchorProps(props as Record<string, unknown>) : props;
 
   return (
     <Tag
-      ref={ref as React.Ref<React.ComponentRef<C>>}
-      role={!isButtonElement ? 'button' : undefined}
-      onClick={handleClick}
+      ref={ref}
       className={classNames(buttonClassName, isDisabled && !isButtonElement && styles.disabled)}
+      onClick={handleClick}
       aria-disabled={isDisabled || undefined}
       aria-busy={loading || undefined}
       data-state={loading ? 'loading' : 'idle'}
       data-testid="button"
-      {...(isButtonElement ? { disabled: isDisabled, type: type || 'button' } : {})}
-      {...props}
+      {...(isNativeInteractive
+        ? isButtonElement
+          ? { disabled: disabled, type: type || 'button' }
+          : {}
+        : { role: 'button', tabIndex: 0, onKeyDown: handleKeyDown })}
+      {...safeProps}
     >
       {loader}
       <span className={contentClassName}>{children}</span>
@@ -119,12 +135,10 @@ ButtonImpl.displayName = 'Button';
  * Button — text-only button with polymorphic `component` prop support.
  *
  * Defaults to rendering a `<button>` element. Use `component="a"` to render as a link,
- * or any other HTML element / React component.
+ * or any other HTML element / React component. Forwards refs correctly (forwardRef + memo).
  */
-export const Button = React.memo(
-  ButtonImpl as React.FC<PolymorphicProps<React.ElementType, ButtonOwnProps>>
-) as <C extends React.ElementType = 'button'>(
-  props: PolymorphicProps<C, ButtonOwnProps> & {
-    ref?: React.ForwardedRef<React.ComponentRef<C>>;
-  }
+export const Button = React.memo(React.forwardRef(ButtonImpl)) as <
+  C extends React.ElementType = 'button',
+>(
+  props: PolymorphicProps<C, ButtonOwnProps> & { ref?: React.ForwardedRef<React.ComponentRef<C>> }
 ) => React.ReactElement;

--- a/src/shared/ui/Button/ui/ButtonLoader/ButtonLoader.tsx
+++ b/src/shared/ui/Button/ui/ButtonLoader/ButtonLoader.tsx
@@ -2,6 +2,7 @@
 // ButtonLoader Component
 // ============================================
 
+import React from 'react';
 import { Spinner } from '@/shared/ui/Spinner';
 import { Skeleton } from '@/shared/ui/Skeleton';
 import { BUTTON_CONSTANTS } from '../../model/constants';
@@ -31,22 +32,26 @@ export interface ButtonLoaderProps {
  * // Renders: <span><Spinner label="Loading" /></span>
  * ```
  */
-export const ButtonLoader = ({
-  loading,
-  loadingVariant = 'spinner',
-  className = '',
-}: ButtonLoaderProps) => {
-  if (!loading) {
-    return null;
-  }
+export const ButtonLoader = React.memo(
+  ({ loading, loadingVariant = 'spinner', className = '' }: ButtonLoaderProps) => {
+    if (!loading) {
+      return null;
+    }
 
-  return loadingVariant === 'spinner' ? (
-    <span className={className}>
-      <Spinner size="sm" color="secondary" label={BUTTON_CONSTANTS.DEFAULT_SPINNER_LABEL} />
-    </span>
-  ) : (
-    <span className={className}>
-      <Skeleton width="100%" height="100%" />
-    </span>
-  );
-};
+    return loadingVariant === 'spinner' ? (
+      <span className={className}>
+        <Spinner
+          size={BUTTON_CONSTANTS.LOADER_SPINNER_SIZE}
+          color={BUTTON_CONSTANTS.LOADER_SPINNER_COLOR}
+          label={BUTTON_CONSTANTS.DEFAULT_SPINNER_LABEL}
+        />
+      </span>
+    ) : (
+      <span className={className}>
+        <Skeleton width="100%" height="100%" />
+      </span>
+    );
+  }
+);
+
+ButtonLoader.displayName = 'ButtonLoader';

--- a/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.module.scss
+++ b/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.module.scss
@@ -47,10 +47,6 @@
     @include variant-sidebar;
   }
 
-  &.danger {
-    @include variant-danger;
-  }
-
   // Color schemes
   @include color-schemes;
 
@@ -122,6 +118,12 @@
 
   &.loading {
     @include button-loading;
+  }
+
+  &.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   // ============================================

--- a/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.test.tsx
+++ b/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.test.tsx
@@ -103,14 +103,15 @@ describe('ButtonWithIcon', () => {
       expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
     });
 
-    it('должен быть disabled при loading=true', () => {
+    it('должен иметь aria-busy и aria-disabled при loading=true (не нативно disabled)', () => {
       render(
         <ButtonWithIcon leftIcon={<Mail />} loading>
           Loading
         </ButtonWithIcon>
       );
 
-      expect(screen.getByRole('button')).toBeDisabled();
+      expect(screen.getByRole('button')).not.toBeDisabled();
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
       expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
     });
 
@@ -156,17 +157,17 @@ describe('ButtonWithIcon', () => {
       expect(screen.getByRole('button')).toHaveClass(buttonWithIconStyles.loading ?? '');
     });
 
-    it('должен скрывать контент при loading=true', () => {
+    it('должен скрывать контент при loading=true (через CSS loading-класс)', () => {
       render(
         <ButtonWithIcon leftIcon={<Mail />} loading>
           Loading
         </ButtonWithIcon>
       );
 
-      const content = screen
-        .getByRole('button')
-        .querySelector(`.${buttonWithIconStyles.content ?? ''}`);
-      expect(content).toHaveClass(buttonWithIconStyles.hidden ?? '');
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass(buttonWithIconStyles.loading ?? '');
+      const content = button.querySelector(`.${buttonWithIconStyles.content ?? ''}`);
+      expect(content).toBeInTheDocument();
     });
   });
 

--- a/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.tsx
+++ b/src/shared/ui/Button/ui/ButtonWithIcon/ButtonWithIcon.tsx
@@ -3,10 +3,12 @@
 // ============================================
 
 import { classNames } from '@/shared/lib/utils/classNames';
-import React from 'react';
+import React, { Children, cloneElement, isValidElement, useMemo } from 'react';
 import type { ButtonOwnProps, ButtonSize, PolymorphicProps } from '../../model/types';
 import { useButton } from '../../lib/hooks/useButton';
 import { inferIconSize } from '../../lib/utils/inferIconSize';
+import { mergeRefs } from '../../lib/utils/mergeRefs';
+import { sanitizeAnchorProps } from '../../lib/utils/sanitizeAnchorProps';
 import styles from './ButtonWithIcon.module.scss';
 
 /**
@@ -34,7 +36,7 @@ import styles from './ButtonWithIcon.module.scss';
  * <ButtonWithIcon component="a" href="/about" leftIcon={<Mail />}>Link</ButtonWithIcon>
  * ```
  */
-function ButtonWithIconImpl<C extends React.ElementType = 'button'>(
+function ButtonWithIconImpl(
   {
     children,
     leftIcon,
@@ -50,32 +52,83 @@ function ButtonWithIconImpl<C extends React.ElementType = 'button'>(
     loading = false,
     loadingVariant = 'spinner',
     component,
-    asChild: _asChild,
+    asChild = false,
     ...props
-  }: PolymorphicProps<
-    C,
-    ButtonOwnProps & { leftIcon?: React.ReactNode; rightIcon?: React.ReactNode }
-  >,
-  ref: React.ForwardedRef<React.ComponentRef<C>>
+  }: PolymorphicProps<React.ElementType, ButtonOwnProps> & {
+    leftIcon?: React.ReactNode;
+    rightIcon?: React.ReactNode;
+  },
+  ref: React.ForwardedRef<React.ComponentRef<React.ElementType>>
 ) {
-  const { buttonClassName, contentClassName, handleClick, loader } = useButton({
-    variant: variant === 'danger' ? 'primary' : variant,
+  const { buttonClassName, contentClassName, handleClick, handleKeyDown, loader } = useButton({
+    variant,
     size,
-    colorScheme: colorScheme ?? (variant === 'danger' ? 'danger' : undefined),
+    colorScheme,
     loading,
     loadingVariant,
     fullWidth,
     disabled,
     className,
     onClick,
-    styles,
+    moduleStyles: styles,
   });
 
+  const isDisabled = disabled || loading;
   const Tag = component || ('button' as React.ElementType);
   const isButtonElement = Tag === 'button';
-  const isDisabled = disabled || loading;
-  const sizedLeftIcon = leftIcon ? inferIconSize(leftIcon, size as ButtonSize) : undefined;
-  const sizedRightIcon = rightIcon ? inferIconSize(rightIcon, size as ButtonSize) : undefined;
+  const isNativeInteractive = isButtonElement || Tag === 'a';
+
+  const sizedLeftIcon = useMemo(
+    () => (leftIcon ? inferIconSize(leftIcon, size as ButtonSize) : undefined),
+    [leftIcon, size]
+  );
+  const sizedRightIcon = useMemo(
+    () => (rightIcon ? inferIconSize(rightIcon, size as ButtonSize) : undefined),
+    [rightIcon, size]
+  );
+
+  // asChild mode: merge button props into a single child element (when one is provided)
+  if (asChild) {
+    /* eslint-disable react-hooks/refs */
+    const childArray = Children.toArray(children);
+    if (childArray.length === 1 && isValidElement(childArray[0])) {
+      const child = childArray[0];
+      const childProps = child.props as Record<string, unknown>;
+      const childOnClick = childProps.onClick as React.MouseEventHandler | undefined;
+      const childRef = childProps.ref as React.Ref<unknown> | undefined;
+
+      const mergedOnClick: React.MouseEventHandler = (event) => {
+        childOnClick?.(event);
+        handleClick(event);
+      };
+      const mergedRef = mergeRefs(ref as React.Ref<unknown>, childRef);
+
+      return cloneElement(child, {
+        className: classNames(
+          buttonClassName,
+          childProps.className as string,
+          isDisabled && styles.disabled
+        ),
+        onClick: mergedOnClick,
+        ref: mergedRef,
+        'aria-disabled': isDisabled || undefined,
+        'aria-busy': loading || undefined,
+        'data-state': loading ? 'loading' : 'idle',
+        'data-testid': 'button-with-icon',
+        ...props,
+      } as Record<string, unknown>) as React.ReactElement;
+    }
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[ButtonWithIcon] asChild requires a single valid child element; falling back to default render.'
+      );
+    }
+    /* eslint-enable react-hooks/refs */
+  }
+
+  // Harden anchor rendering: sanitize href scheme + rel="noopener noreferrer" for _blank
+  const safeProps = Tag === 'a' ? sanitizeAnchorProps(props as Record<string, unknown>) : props;
 
   const iconContent = (
     <>
@@ -87,16 +140,19 @@ function ButtonWithIconImpl<C extends React.ElementType = 'button'>(
 
   return (
     <Tag
-      ref={ref as React.Ref<React.ComponentRef<C>>}
-      role={!isButtonElement ? 'button' : undefined}
-      onClick={handleClick}
+      ref={ref}
       className={classNames(buttonClassName, isDisabled && !isButtonElement && styles.disabled)}
+      onClick={handleClick}
       aria-disabled={isDisabled || undefined}
       aria-busy={loading || undefined}
       data-state={loading ? 'loading' : 'idle'}
       data-testid="button-with-icon"
-      {...(isButtonElement ? { disabled: isDisabled, type: type || 'button' } : {})}
-      {...props}
+      {...(isNativeInteractive
+        ? isButtonElement
+          ? { disabled: disabled, type: type || 'button' }
+          : {}
+        : { role: 'button', tabIndex: 0, onKeyDown: handleKeyDown })}
+      {...safeProps}
     >
       {loader}
       <span className={contentClassName}>{iconContent}</span>
@@ -111,15 +167,11 @@ ButtonWithIconImpl.displayName = 'ButtonWithIcon';
  *
  * Defaults to rendering a `<button>` element. Use `component="a"` to render as a link.
  * Icon size is auto-inferred from button size unless the icon has an explicit `size` prop.
+ * Forwards refs correctly (forwardRef + memo).
  */
-export const ButtonWithIcon = React.memo(
-  ButtonWithIconImpl as React.FC<
-    PolymorphicProps<
-      React.ElementType,
-      ButtonOwnProps & { leftIcon?: React.ReactNode; rightIcon?: React.ReactNode }
-    >
-  >
-) as <C extends React.ElementType = 'button'>(
+export const ButtonWithIcon = React.memo(React.forwardRef(ButtonWithIconImpl)) as <
+  C extends React.ElementType = 'button',
+>(
   props: PolymorphicProps<
     C,
     ButtonOwnProps & { leftIcon?: React.ReactNode; rightIcon?: React.ReactNode }

--- a/src/shared/ui/Button/ui/IconButton/IconButton.module.scss
+++ b/src/shared/ui/Button/ui/IconButton/IconButton.module.scss
@@ -43,10 +43,6 @@
     @include variant-sidebar;
   }
 
-  &.danger {
-    @include variant-danger;
-  }
-
   // Color schemes
   @include color-schemes;
 
@@ -123,6 +119,12 @@
       width: 50%;
       height: 50%;
     }
+  }
+
+  &.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   // ============================================

--- a/src/shared/ui/Button/ui/IconButton/IconButton.test.tsx
+++ b/src/shared/ui/Button/ui/IconButton/IconButton.test.tsx
@@ -87,10 +87,12 @@ describe('IconButton', () => {
       expect(screen.getByRole('button')).toBeDisabled();
     });
 
-    it('должен быть disabled при loading=true', () => {
+    it('должен иметь aria-busy и aria-disabled при loading=true (не нативно disabled)', () => {
       render(<IconButton icon={<Mail />} ariaLabel="Icon" loading />);
 
-      expect(screen.getByRole('button')).toBeDisabled();
+      expect(screen.getByRole('button')).not.toBeDisabled();
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
+      expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
     });
   });
 

--- a/src/shared/ui/Button/ui/IconButton/IconButton.tsx
+++ b/src/shared/ui/Button/ui/IconButton/IconButton.tsx
@@ -3,10 +3,12 @@
 // ============================================
 
 import { classNames } from '@/shared/lib/utils/classNames';
-import React from 'react';
+import React, { isValidElement, cloneElement, useMemo } from 'react';
 import type { ButtonOwnProps, ButtonSize, PolymorphicProps } from '../../model/types';
 import { useButton } from '../../lib/hooks/useButton';
 import { inferIconSize } from '../../lib/utils/inferIconSize';
+import { mergeRefs } from '../../lib/utils/mergeRefs';
+import { sanitizeAnchorProps } from '../../lib/utils/sanitizeAnchorProps';
 import styles from './IconButton.module.scss';
 
 /**
@@ -30,7 +32,7 @@ import styles from './IconButton.module.scss';
  * <IconButton icon={<Edit size={20} />} ariaLabel="Edit" loading />
  * ```
  */
-function IconButtonImpl<C extends React.ElementType = 'button'>(
+function IconButtonImpl(
   {
     icon,
     ariaLabel,
@@ -45,42 +47,87 @@ function IconButtonImpl<C extends React.ElementType = 'button'>(
     loading = false,
     loadingVariant = 'spinner',
     component,
-    asChild: _asChild,
+    asChild = false,
     ...props
-  }: PolymorphicProps<C, ButtonOwnProps & { icon: React.ReactNode; ariaLabel: string }>,
-  ref: React.ForwardedRef<React.ComponentRef<C>>
+  }: PolymorphicProps<React.ElementType, ButtonOwnProps> & {
+    icon?: React.ReactNode;
+    ariaLabel?: string;
+  },
+  ref: React.ForwardedRef<React.ComponentRef<React.ElementType>>
 ) {
-  const { buttonClassName, contentClassName, handleClick, loader } = useButton({
-    variant: variant === 'danger' ? 'primary' : variant,
+  const { buttonClassName, contentClassName, handleClick, handleKeyDown, loader } = useButton({
+    variant,
     size,
-    colorScheme: colorScheme ?? (variant === 'danger' ? 'danger' : undefined),
+    colorScheme,
     loading,
     loadingVariant,
     fullWidth,
     disabled,
     className,
     onClick,
-    styles,
+    moduleStyles: styles,
   });
 
+  const isDisabled = disabled || loading;
   const Tag = component || ('button' as React.ElementType);
   const isButtonElement = Tag === 'button';
-  const isDisabled = disabled || loading;
-  const sizedIcon = inferIconSize(icon, size as ButtonSize);
+  const isNativeInteractive = isButtonElement || Tag === 'a';
+
+  const sizedIcon = useMemo(
+    () => (icon ? inferIconSize(icon, size as ButtonSize) : null),
+    [icon, size]
+  );
+
+  // asChild mode: merge button props into the provided icon element (cloned)
+  if (asChild && isValidElement(icon)) {
+    /* eslint-disable react-hooks/refs */
+    const iconProps = icon.props as Record<string, unknown>;
+    const childOnClick = iconProps.onClick as React.MouseEventHandler | undefined;
+    const childRef = iconProps.ref as React.Ref<unknown> | undefined;
+
+    const mergedOnClick: React.MouseEventHandler = (event) => {
+      childOnClick?.(event);
+      handleClick(event);
+    };
+    const mergedRef = mergeRefs(ref as React.Ref<unknown>, childRef);
+
+    return cloneElement(icon, {
+      className: classNames(
+        buttonClassName,
+        iconProps.className as string,
+        isDisabled && styles.disabled
+      ),
+      onClick: mergedOnClick,
+      ref: mergedRef,
+      'aria-label': ariaLabel,
+      'aria-disabled': isDisabled || undefined,
+      'aria-busy': loading || undefined,
+      'data-state': loading ? 'loading' : 'idle',
+      'data-testid': 'icon-button',
+      ...props,
+    } as Record<string, unknown>) as React.ReactElement;
+    /* eslint-enable react-hooks/refs */
+  }
+
+  // Harden anchor rendering: sanitize href scheme + rel="noopener noreferrer" for _blank
+  const safeProps = Tag === 'a' ? sanitizeAnchorProps(props as Record<string, unknown>) : props;
 
   return (
     <Tag
-      ref={ref as React.Ref<React.ComponentRef<C>>}
-      role={!isButtonElement ? 'button' : undefined}
-      onClick={handleClick}
+      ref={ref}
       className={classNames(buttonClassName, isDisabled && !isButtonElement && styles.disabled)}
+      onClick={handleClick}
       aria-label={ariaLabel}
       aria-disabled={isDisabled || undefined}
       aria-busy={loading || undefined}
       data-state={loading ? 'loading' : 'idle'}
       data-testid="icon-button"
-      {...(isButtonElement ? { disabled: isDisabled, type: type || 'button' } : {})}
-      {...props}
+      {...(isNativeInteractive
+        ? isButtonElement
+          ? { disabled: disabled, type: type || 'button' }
+          : {}
+        : { role: 'button', tabIndex: 0, onKeyDown: handleKeyDown })}
+      {...safeProps}
     >
       {loader}
       <span className={contentClassName}>{sizedIcon}</span>
@@ -95,15 +142,11 @@ IconButtonImpl.displayName = 'IconButton';
  *
  * Defaults to rendering a `<button>` element. Use `component="a"` to render as a link.
  * Icon size is auto-inferred from button size unless the icon has an explicit `size` prop.
+ * Forwards refs correctly (forwardRef + memo).
  */
-export const IconButton = React.memo(
-  IconButtonImpl as React.FC<
-    PolymorphicProps<
-      React.ElementType,
-      ButtonOwnProps & { icon: React.ReactNode; ariaLabel: string }
-    >
-  >
-) as <C extends React.ElementType = 'button'>(
+export const IconButton = React.memo(React.forwardRef(IconButtonImpl)) as <
+  C extends React.ElementType = 'button',
+>(
   props: PolymorphicProps<C, ButtonOwnProps & { icon: React.ReactNode; ariaLabel: string }> & {
     ref?: React.ForwardedRef<React.ComponentRef<C>>;
   }

--- a/src/shared/ui/Modal/ui/ModalForm/ModalForm.tsx
+++ b/src/shared/ui/Modal/ui/ModalForm/ModalForm.tsx
@@ -36,7 +36,7 @@ export const ModalForm = memo((props: ModalFormProps) => {
           <Button
             variant="primary"
             loading={loading}
-            disabled={disableSubmit}
+            disabled={loading || disableSubmit}
             type="submit"
             form="modal-form"
           >


### PR DESCRIPTION
## Summary
Реализованы все MAJOR + MINOR находки 4R-ревью компонента Button (issue #51).
Ревью проведено в 4 линзы (R1 Security / R2 Readability / R3 Reliability / R4 Resilience).

### Applied fixes
- **R3-F1** `forwardRef` + `React.memo` на `Button`/`IconButton`/`ButtonWithIcon` (ref теперь корректно пробрасывается в React 19).
- **R2** орфан-типы: `ButtonProps`/`IconButtonProps`/`ButtonWithIconProps` наследуют `ButtonOwnProps`; удалён неиспользуемый `BaseButtonProps`; `colorScheme` передаётся в `validateButtonProps` + в deps.
- **R1** XSS: `lib/utils/safeHref.ts` блокирует `javascript:`/`data:` href; `sanitizeAnchorProps.ts` добавляет `rel="noopener noreferrer"` для `target="_blank"`.
- **R4-MAJOR1** `loading` больше НЕ ставит нативный `disabled` (сохраняет `aria-busy`/`aria-disabled` для скринридеров).
- **R3-F3** клавиатурная доступность не-native элементов (`role="button"`, `tabIndex=0`, `onKeyDown` Enter/Space).
- **R2-F3/F7** centralize danger -> `primary` + `colorScheme:'danger'`.
- **R2-F5/F6/F9** удалены мёртвые `hidden`/`danger` CSS-классы; опция хука `styles` -> `moduleStyles`.
- **R3-F2/F7** `asChild` мержит `onClick`/ref дочернего элемента; `ButtonWithIcon` клонирует children (dev-warn при не-одиночном child).
- **R2-F8 / R4-MINOR1/2** `useMemo` для `inferIconSize`; `React.memo(ButtonLoader)`; magic-литералы -> `BUTTON_CONSTANTS`.

### Follow-up (coupled)
- **ModalForm** (`src/shared/ui/Modal/ui/ModalForm/ModalForm.tsx`): поскольку Button больше не дисейблит нативно при loading, submit-кнопка формы явно ставит `disabled={loading || disableSubmit}`, чтобы предотвратить double-submit.

### Tests
- Обновлены тесты под новое поведение loading (aria-busy вместо нативного disabled; удалён `hidden`/`danger` классы).
- Добавлены тесты: блокировка `javascript:` href, `rel` для `_blank`.

### Verification
- `npm run validate` GREEN (type-check + eslint + stylelint + 2256 unit-тестов, coverage ↑).

## Test plan
- [ ] `npm run validate` локально зелёный
- [ ] Визуальная проверка loading-состояния (кнопка НЕ "серая/disabled", но недоступна)
- [ ] Проверка `target="_blank"` ссылок на `rel="noopener noreferrer"`

Closes #51