### PR TITLE
refactor(card): P1 reliability and behavior (card-4r #57) [stacked on P0 #60]

### DIFF
--- a/src/shared/ui/Card/index.ts
+++ b/src/shared/ui/Card/index.ts
@@ -6,13 +6,7 @@
 export type { BaseCardProps, CardVariant, CardSize, CardRadius, TechIcon } from './model/types';
 
 // Specialized card types
-export type {
-  ProjectCardProps,
-  WorkHistoryCardProps,
-  ContactCardProps,
-  SkillCardProps,
-  AboutCardProps,
-} from './model/types';
+export type { ProjectCardProps, WorkHistoryCardProps, ContactCardProps } from './model/types';
 
 // Composition API types
 export type {
@@ -21,9 +15,6 @@ export type {
   CardFooterProps,
   CardImageProps,
 } from './model/types';
-
-// Event types
-export type { CardClickEvent, CardClickHandler, CardHoverHandler } from './model/types';
 
 // Constants for configuration and validation
 export { CARD_CONSTANTS } from './model/constants';

--- a/src/shared/ui/Card/lib/utils/validateCardProps.test.ts
+++ b/src/shared/ui/Card/lib/utils/validateCardProps.test.ts
@@ -24,17 +24,8 @@ describe('validateCardProps', () => {
     );
   });
 
-  it('warns when hoverable is set without onClick', () => {
-    expect(
-      validateCardProps('default', 'default', 'rounded', true).some((w) => w.prop === 'onClick')
-    ).toBe(true);
-  });
-
-  it('does not warn when hoverable has onClick', () => {
-    expect(
-      validateCardProps('default', 'default', 'rounded', true, () => {}).some(
-        (w) => w.prop === 'onClick'
-      )
-    ).toBe(false);
+  it('does NOT warn for hoverable without onClick (CARD-P1-2 removed the flood)', () => {
+    const warnings = validateCardProps('default', 'default', 'rounded');
+    expect(warnings.some((w) => w.prop === 'onClick')).toBe(false);
   });
 });

--- a/src/shared/ui/Card/lib/utils/validateCardProps.ts
+++ b/src/shared/ui/Card/lib/utils/validateCardProps.ts
@@ -8,9 +8,7 @@ export interface CardValidationWarning {
 export const validateCardProps = (
   variant: string,
   size: string,
-  radius: string,
-  hoverable?: boolean,
-  onClick?: unknown
+  radius: string
 ): CardValidationWarning[] => {
   const warnings: CardValidationWarning[] = [];
 
@@ -35,14 +33,6 @@ export const validateCardProps = (
     warnings.push({
       prop: 'radius',
       message: `[Card] Invalid radius "${radius}". Valid values: ${validRadii.join(', ')}`,
-    });
-  }
-
-  if (hoverable && !onClick) {
-    warnings.push({
-      prop: 'onClick',
-      message:
-        '[Card] hoverable is true but onClick is not provided. Hover effects will have no interaction.',
     });
   }
 

--- a/src/shared/ui/Card/model/types.ts
+++ b/src/shared/ui/Card/model/types.ts
@@ -5,9 +5,9 @@
 import {
   HTMLAttributes,
   ReactNode,
-  MouseEvent,
   ElementType,
   ComponentPropsWithoutRef,
+  CSSProperties,
 } from 'react';
 
 // ============================================
@@ -88,6 +88,8 @@ export interface ProjectCardProps extends Omit<CardOwnProps, 'variant' | 'size' 
   link?: string | null;
   linkLabel?: string;
   builtUsingLabel?: string;
+  /** CARD-P1-1: constrained style passthrough (D2) merged onto the root element. */
+  style?: CSSProperties;
 }
 
 /**
@@ -101,6 +103,8 @@ export interface WorkHistoryCardProps extends Omit<CardOwnProps, 'variant' | 'si
   location?: string;
   achievements?: string[];
   techStack?: string[];
+  /** CARD-P1-1: constrained style passthrough (D2) merged onto the root element. */
+  style?: CSSProperties;
 }
 
 /**
@@ -110,24 +114,8 @@ export interface ContactCardProps extends Omit<CardOwnProps, 'variant' | 'size' 
   title?: string;
   icon?: ReactNode;
   children?: ReactNode;
-}
-
-/**
- * Props для карточки навыка (SkillCard)
- */
-export interface SkillCardProps extends CardOwnProps {
-  skillName?: string;
-  level?: number;
-  techIcons?: TechIcon[];
-}
-
-/**
- * Props для карточки About (AboutCard)
- */
-export interface AboutCardProps extends CardOwnProps {
-  title?: string;
-  icon?: ReactNode;
-  children?: ReactNode;
+  /** CARD-P1-1: constrained style passthrough (D2) merged onto the root element. */
+  style?: CSSProperties;
 }
 
 // ============================================
@@ -219,16 +207,3 @@ export interface CardMetaProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   className?: string;
 }
-
-// ============================================
-// Event Types
-// ============================================
-
-export interface CardClickEvent {
-  originalEvent: MouseEvent<HTMLDivElement>;
-  targetType: 'card' | 'header' | 'footer' | 'body';
-}
-
-export type CardClickHandler = (event: CardClickEvent) => void;
-
-export type CardHoverHandler = (isHovered: boolean) => void;

--- a/src/shared/ui/Card/model/useCard.ts
+++ b/src/shared/ui/Card/model/useCard.ts
@@ -93,7 +93,12 @@ export function useCard({
   href,
   isLink,
 }: UseCardConfig): UseCardReturn {
-  const safeVariant = variant ?? CARD_CONSTANTS.DEFAULT_VARIANT;
+  // CARD-P1-4: clamp an invalid variant string to DEFAULT_VARIANT so a stray
+  // value never survives into `styles[safeVariant]` (which would resolve undefined).
+  const safeVariant: CardOwnProps['variant'] =
+    variant !== undefined && CARD_CONSTANTS.VALID_VARIANTS.includes(variant)
+      ? variant
+      : CARD_CONSTANTS.DEFAULT_VARIANT;
   const safeSize = size ?? CARD_CONSTANTS.DEFAULT_SIZE;
   const safeRadius = radius ?? CARD_CONSTANTS.DEFAULT_RADIUS;
 
@@ -101,7 +106,13 @@ export function useCard({
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
-      const warnings = validateCardProps(safeVariant, safeSize, safeRadius, hoverable, onClick);
+      // Pass the ORIGINAL `variant` (not the clamped safeVariant) so the
+      // dev-only invalid-variant warning still fires for stray strings.
+      const warnings = validateCardProps(
+        variant ?? CARD_CONSTANTS.DEFAULT_VARIANT,
+        safeSize,
+        safeRadius
+      );
       warnings.forEach((w: { message: string }) => {
         // eslint-disable-next-line no-console
         console.warn(w.message);
@@ -118,7 +129,7 @@ export function useCard({
         );
       }
     }
-  }, [safeVariant, safeSize, safeRadius, hoverable, onClick, component, href, isLink]);
+  }, [safeVariant, safeSize, safeRadius, hoverable, onClick, component, href, isLink, variant]);
 
   const cardClasses = useMemo(
     () =>

--- a/src/shared/ui/Card/ui/Card.stories.tsx
+++ b/src/shared/ui/Card/ui/Card.stories.tsx
@@ -451,3 +451,55 @@ export const InteractiveKeyboard: Story = {
     expect(canvas.getByText('Clicks: 2')).toBeInTheDocument();
   },
 };
+
+// ============================================
+// CARD-P1-3 — behavior interaction tests (Playwright via test:storybook)
+// ============================================
+
+export const P1ClickFiresOnClick: Story = {
+  render: () => {
+    const [count, setCount] = React.useState(0);
+    return (
+      <Card onClick={() => setCount((c) => c + 1)} data-testid="click-card">
+        <p>Clicks: {count}</p>
+      </Card>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByRole('button');
+    expect(card).toHaveAttribute('tabindex', '0');
+    await userEvent.click(card);
+    expect(canvas.getByText('Clicks: 1')).toBeInTheDocument();
+  },
+};
+
+export const P1ClassNameForwarded: Story = {
+  render: () =>
+    S({
+      variant: 'project',
+      className: 'story-extra',
+      fullWidth: true,
+      title: 'Demo Project',
+      description: 'Forwarded class + fullWidth',
+      techIcons: [],
+    }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = canvas.getByText('Demo Project');
+    const root = title.closest('[class*="projectCard"]') as HTMLElement | null;
+    expect(root).toBeInTheDocument();
+    expect(root).toHaveClass('story-extra');
+  },
+};
+
+export const P1InvalidVariantDefault: Story = {
+  render: () =>
+    S({ variant: 'foo', 'data-testid': 'bad-variant', children: 'Invalid variant content' }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const card = canvas.getByTestId('bad-variant');
+    expect(card).toHaveAttribute('data-variant', 'default');
+    expect(card).toBeInTheDocument();
+  },
+};

--- a/src/shared/ui/Card/ui/Card.test.tsx
+++ b/src/shared/ui/Card/ui/Card.test.tsx
@@ -15,6 +15,9 @@ import { WorkHistoryCard } from './WorkHistoryCard';
 import { ContactCard } from './ContactCard';
 import cardDescriptionStyles from './CardDescription/CardDescription.module.scss';
 import projectCardStyles from './ProjectCard/ProjectCard.module.scss';
+import cardStyles from './Card.module.scss';
+import contactCardStyles from './ContactCard/ContactCard.module.scss';
+import type { CardVariant } from '../model/types';
 
 describe('Card', () => {
   describe('Rendering', () => {
@@ -849,5 +852,120 @@ describe('CARD-P0-4 interactive a11y', () => {
     const btn = container.firstChild as HTMLElement;
     expect(btn).toHaveAttribute('role', 'button');
     expect(btn).not.toHaveAttribute('tabindex');
+  });
+});
+
+// ============================================
+// CARD-P1 — reliability / behavior (strict TDD)
+// ============================================
+
+describe('CARD-P1 reliability & behavior', () => {
+  describe('CARD-P1-1 className/style/fullWidth forwarding', () => {
+    it('forwards className + fullWidth into ProjectCard (specialized component)', () => {
+      const { container } = render(
+        <ProjectCard className="extra" fullWidth title="P" description="D" techIcons={[]} />
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass(projectCardStyles.projectCard ?? '');
+      expect(root).toHaveClass('extra');
+      expect(root).toHaveClass(projectCardStyles.fullWidth ?? '');
+    });
+
+    it('forwards style into ContactCard and merges className', () => {
+      const { container } = render(
+        <ContactCard className="extra2" style={{ marginTop: 8 }} title="C">
+          child
+        </ContactCard>
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass(contactCardStyles.contactCard ?? '');
+      expect(root).toHaveClass('extra2');
+      expect(root.style.marginTop).toBe('8px');
+    });
+
+    it('Card forwards className + fullWidth into the ProjectCard delegation branch', () => {
+      const { container } = render(
+        <Card variant="project" className="fwd" fullWidth>
+          child
+        </Card>
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass(projectCardStyles.projectCard ?? '');
+      expect(root).toHaveClass('fwd');
+      expect(root).toHaveClass(projectCardStyles.fullWidth ?? '');
+    });
+  });
+
+  describe('CARD-P1-2 no-warn on hoverable', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('plain <Card hoverable> emits zero console.warn', () => {
+      render(<Card hoverable>content</Card>);
+      // eslint-disable-next-line no-console
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CARD-P1-3 behavior', () => {
+    it('click fires onClick on an interactive card', () => {
+      const onClick = vi.fn();
+      const { container } = render(<Card onClick={onClick}>clickable</Card>);
+      fireEvent.click(container.firstChild as HTMLElement);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter/Space fire onClick (no double-fire) on an interactive card', () => {
+      const onClick = vi.fn();
+      const { container } = render(<Card onClick={onClick}>clickable</Card>);
+      const root = container.firstChild as HTMLElement;
+      fireEvent.keyDown(root, { key: 'Enter' });
+      fireEvent.keyDown(root, { key: ' ' });
+      expect(onClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('ref resolves to the rendered DOM node', () => {
+      const ref = createRef<HTMLDivElement>();
+      render(<Card ref={ref}>content</Card>);
+      expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it('specialized variant forwards className (ProjectCard via Card.Project)', () => {
+      const { container } = render(
+        <Card.Project className="fwd" fullWidth title="P" description="D" techIcons={[]} />
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveClass(projectCardStyles.projectCard ?? '');
+      expect(root).toHaveClass('fwd');
+    });
+  });
+
+  describe('CARD-P1-4 invalid variant → default fallback', () => {
+    it('renders the default class, applies no styles.foo, and does not crash', () => {
+      const { container } = render(
+        <Card variant={'foo' as CardVariant} data-testid="bad-variant">
+          content
+        </Card>
+      );
+      const root = container.firstChild as HTMLElement;
+      expect(root).toHaveAttribute('data-variant', 'default');
+      expect(root).toHaveClass(cardStyles.default ?? '');
+      expect(root.className).not.toMatch(/\bfoo\b/);
+      expect(root).toBeInTheDocument();
+    });
+
+    it('valid variant (skill) is unaffected', () => {
+      render(
+        <Card variant="skill" data-testid="good-variant">
+          content
+        </Card>
+      );
+      const root = screen.getByTestId('good-variant').closest('[data-variant]') as HTMLElement;
+      expect(root).toHaveAttribute('data-variant', 'skill');
+    });
   });
 });

--- a/src/shared/ui/Card/ui/Card.tsx
+++ b/src/shared/ui/Card/ui/Card.tsx
@@ -123,6 +123,7 @@ const CardImpl = forwardRef(function Card<C extends ElementType = 'div'>(
     hoverable,
     className,
     component,
+    style,
     children,
     ...rest
   }: CardProps<C>,
@@ -145,17 +146,32 @@ const CardImpl = forwardRef(function Card<C extends ElementType = 'div'>(
     isLink,
   });
 
+  // CARD-P1-1: forward className/fullWidth/style into specialized variants, merged
+  // with each variant's own base class inside the specialized component.
   if (safeVariant === 'project') {
-    return createElement(ProjectCard, sanitizeRest(rest) as unknown as ProjectCardProps);
+    return createElement(ProjectCard, {
+      ...(sanitizeRest(rest) as unknown as ProjectCardProps),
+      className,
+      fullWidth,
+      style,
+    });
   }
 
   if (safeVariant === 'workHistory') {
-    return createElement(WorkHistoryCard, sanitizeRest(rest) as unknown as WorkHistoryCardProps);
+    return createElement(WorkHistoryCard, {
+      ...(sanitizeRest(rest) as unknown as WorkHistoryCardProps),
+      className,
+      fullWidth,
+      style,
+    });
   }
 
   if (safeVariant === 'contact') {
     return createElement(ContactCard, {
       ...(sanitizeRest(rest) as unknown as ContactCardProps),
+      className,
+      fullWidth,
+      style,
       children,
     });
   }
@@ -176,6 +192,7 @@ const CardImpl = forwardRef(function Card<C extends ElementType = 'div'>(
       'data-size': safeSize,
       'data-radius': safeRadius,
       ...sanitizeRest(rest),
+      style,
       role: interactivity.role,
       tabIndex: interactivity.tabIndex,
       onKeyDown: interactivity.onKeyDown,

--- a/src/shared/ui/Card/ui/ContactCard/ContactCard.tsx
+++ b/src/shared/ui/Card/ui/ContactCard/ContactCard.tsx
@@ -31,9 +31,14 @@ const ContactCardComponent: React.FC<ContactCardProps> = ({
   icon,
   children,
   className = '',
+  fullWidth,
+  style,
 }) => {
   return (
-    <div className={classNames(styles.contactCard, className)}>
+    <div
+      className={classNames(styles.contactCard, fullWidth && styles.fullWidth, className)}
+      style={style}
+    >
       <div className={styles.centeredContent}>
         {icon && <div className={styles.iconWrapper}>{icon}</div>}
         {title && <h3 className={styles.title}>{title}</h3>}

--- a/src/shared/ui/Card/ui/ProjectCard/ProjectCard.tsx
+++ b/src/shared/ui/Card/ui/ProjectCard/ProjectCard.tsx
@@ -40,12 +40,17 @@ const ProjectCardComponent: React.FC<ProjectCardProps> = ({
   builtUsingLabel = 'Создано с помощью',
   linkLabel = 'Ссылка',
   className = '',
+  fullWidth,
+  style,
 }) => {
   // CARD-P0-5: sanitize the backgroundImage; skip the layer on rejection (no throw).
   const safeBackground = sanitizeBackgroundImage(backgroundImage);
 
   return (
-    <div className={classNames(styles.projectCard, className)}>
+    <div
+      className={classNames(styles.projectCard, fullWidth && styles.fullWidth, className)}
+      style={style}
+    >
       {safeBackground && (
         <div className={styles.backgroundImage} style={{ backgroundImage: safeBackground }} />
       )}

--- a/src/shared/ui/Card/ui/WorkHistoryCard/WorkHistoryCard.tsx
+++ b/src/shared/ui/Card/ui/WorkHistoryCard/WorkHistoryCard.tsx
@@ -40,9 +40,14 @@ const WorkHistoryCardComponent: React.FC<WorkHistoryCardProps> = ({
   achievements,
   techStack,
   className = '',
+  fullWidth,
+  style,
 }) => {
   return (
-    <div className={classNames(styles.workHistoryCard, className)}>
+    <div
+      className={classNames(styles.workHistoryCard, fullWidth && styles.fullWidth, className)}
+      style={style}
+    >
       <div className={styles.header}>
         <div className={styles.titleSection}>
           <h3 className={styles.title}>{title}</h3>


### PR DESCRIPTION
SDD card-4r, SLICE 2/3 = P1 (T06-T10). Issue #57. База — PR #60 (P0), stacked.

- T06 forward className/style/fullWidth в специализированные варианты
- T07 убран dev-warn-флуд hoverable && !onClick; тест zero console.warn
- T08 поведенческие тесты: click + Enter/Space, ref-forwarding, variant className, invalid-variant fallback
- T09 невалидный variant -> default class (VALID_VARIANTS guard)
- T10 удалены осиротевшие типы (SkillCardProps/AboutCardProps/CardClickEvent/CardClickHandler/CardHoverHandler)

Гейты GREEN: npm run validate + npm run test:storybook (655 interaction).
Следующий срез: P2 (T11-T16) — отдельным PR (stacked на этот).